### PR TITLE
Implement stream summary notifications with end-of-stream metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This is the successor of [eop-blive](https://subspace.institute/docs/eye-of-prov
 - Automatic reconnection support for each bridge
 - YAML-based configuration
 - Fault tolerance - continues running even if some bridges fail
+- End-of-stream summary notifications (chat, audience, revenue, highlights)
 
 ## How It Works
 
@@ -49,6 +50,25 @@ Example log output:
 [primary] Event from room 明前奶绿 (25034104): message
 [secondary] Event from room 明前奶绿 (25034104): gift
 ```
+
+## Stream Summary
+
+When a monitored stream ends, the bot posts a single summary to the room's
+`telegram_announce_ch` with the stream's duration, chat activity, audience
+(看过 / peak online / likes / new follows), monetary totals (gifts, super
+chats, 大航海), and per-user highlights (top gifter, biggest super chat, most
+active chatter).
+
+Metrics are accumulated **in memory** — there is no database, and an in-progress
+stream's totals are lost if the process restarts. Bilibili fires
+`live-start`/`live-end` repeatedly and flaps on brief drops, so the summary is
+sent after a debounce window (`STREAM_SUMMARY_DEBOUNCE_MS`, default 45s) once the
+stream has truly ended.
+
+> **Multi-bridge note:** counts assume each room is pinned to a single `bridge`.
+> If a room is monitored by multiple bridges, duplicate events will inflate the
+> summary — pin the room to one bridge (as you already do to avoid duplicate
+> notifications).
 
 ## Prerequisites
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,11 +5,11 @@
     "": {
       "name": "laplace-jupiter",
       "dependencies": {
-        "@laplace.live/event-bridge-sdk": "^1.0.24",
+        "@laplace.live/event-bridge-sdk": "^1.1.0",
         "@mtcute/bun": "0.29.7",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.4.15",
+        "@biomejs/biome": "^2.5.0",
         "@changesets/cli": "^2.31.0",
         "@types/bun": "^1.3.14",
       },
@@ -21,23 +21,23 @@
   "packages": {
     "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.4.15", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.15", "@biomejs/cli-darwin-x64": "2.4.15", "@biomejs/cli-linux-arm64": "2.4.15", "@biomejs/cli-linux-arm64-musl": "2.4.15", "@biomejs/cli-linux-x64": "2.4.15", "@biomejs/cli-linux-x64-musl": "2.4.15", "@biomejs/cli-win32-arm64": "2.4.15", "@biomejs/cli-win32-x64": "2.4.15" }, "bin": { "biome": "bin/biome" } }, "sha512-j5VH3a/h/HXTKBM50MDMxRCzkeLv9S2XJcW2WgnZT1+xyisi+0bISrXR82gCX+8S9lvK0skEvHJRN+3Ktr2hlw=="],
+    "@biomejs/biome": ["@biomejs/biome@2.5.0", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.0", "@biomejs/cli-darwin-x64": "2.5.0", "@biomejs/cli-linux-arm64": "2.5.0", "@biomejs/cli-linux-arm64-musl": "2.5.0", "@biomejs/cli-linux-x64": "2.5.0", "@biomejs/cli-linux-x64-musl": "2.5.0", "@biomejs/cli-win32-arm64": "2.5.0", "@biomejs/cli-win32-x64": "2.5.0" }, "bin": { "biome": "bin/biome" } }, "sha512-4kURkd9hAPrdDM3C9n82ycYgx8hvQcW6MjKTEejruj8rK0N8P3OPpdy8BvI8kt3KWY4ycF5XtDOrktetEfhfuw=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.15", "", { "os": "darwin", "cpu": "arm64" }, "sha512-rF3PPqLq1yoST79zaQbDjVJwsuIeci/O+9bgNmC5QpgOqz6aqYuzA4abyAGx+mgyiDXn4A049xAN8gijbuR1Qg=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Mn3Fwi3SA5fgmfCPqmzpWF2DLZnms3BVAhM088nTnGrTZmHS3wwIjcoZPqpXeNgd3DrrLH6xp8vTLIBuJoZiXw=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.15", "", { "os": "darwin", "cpu": "x64" }, "sha512-/5KHXYMfSJs1fNXiX30xFtI8JcCFV6zaVVLxOa0M2sfqBKHkpQhRTv94yxQWxeTY2lzo2OuTlNvPC+hDQt2wcQ=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-rg3VPL5P8mYro6pqlXYXuJWph21slVp3SZtAqWSrkZs40d2gTzYmHF8E/X1iTID25btmNKltNDJ926sqVBp7DQ=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-owaAMZD/T4LrD0ELNCk0Km3qrRHuM0X6EAyVE1FSqGY0rbLoiDLrO4Us2tllm6cAeB2Ioa9C2C08NZPdr8+0Ug=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-tl+LW8fdD96/xdeWtWwc82LIOc5CoY7N2AsogLTp5R4ECErYt+8Jl/N68ezN9vzSiqPTxw6vjcihoLPYKZHrlw=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-ZPcxznxm0pogHBLZhYntyR3sR+MrZjqJIKEr7ZqVen0Rl+P/4upVmfYXjftizi9RoqZntg33fv/1fbdhbYXpEQ=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-vQdM4oSGaf7ZNeGO9w5+Y8SBtyser9M6znxYbm7Ec8wInxJu1WiKxFYZW5Auj2d80bcVvefuGGRxoFOE0eee8g=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.15", "", { "os": "linux", "cpu": "x64" }, "sha512-0jj7THz12GbUOLmMibktK6DZjqz2zV64KFxyBtcFTKPiiOIY0a7vns1elpO1dERvxpsZ5ik0oFfz0oGwFde1+g=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.0", "", { "os": "linux", "cpu": "x64" }, "sha512-zpEGf4RQbFEh8Vt7OmavLyyOzRbtcE9osCqrS1kfvt8jDvxwhKXLSf7n0ebr/ov0RJ9ssP+lhs6C8a9WwFvrQA=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.15", "", { "os": "linux", "cpu": "x64" }, "sha512-CNq/9W38SYSH023lfcQ4KKU8K0YX8T//FZUhcgtMMRABDojx5XsMV7jlweAvGSl389wJQB29Qo6Zb/a+jdvt+w=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.0", "", { "os": "linux", "cpu": "x64" }, "sha512-+9hIcMngJ+yGUahXqZuZ8CoWKJE9SAZsFsM3QDvXpNsLbXZ9lqVzgBhOk/jTSYkOA0GLP9eu3teukqpLUojHMg=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.15", "", { "os": "win32", "cpu": "arm64" }, "sha512-ouhkYdlhp/1GghEJPdWwD/Vi3gQ1nFxuSpMolWsbq3Lsq3QUR4jl6UdhhscdCugKU5vOEuMiJhvKj66O0OCq+w=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-jB0wAvTLI4itx5VidqVUejPQFhRUxiZ9l9FvZ26D5fl6t3qme+ZB4PD3bTSeL1vZ8NI2Rx/zj6H9zcESuGHKGw=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.15", "", { "os": "win32", "cpu": "x64" }, "sha512-zBrGq5mx5wwpnow4+2BxUvleDM+GNd4sLbPaMapsSLQLD0NGRCquqPBTgN+7XkUteHvj7M+BstuI8tmnV7+HgQ=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.0", "", { "os": "win32", "cpu": "x64" }, "sha512-VT/lF+GId+67j8aDfLkxdxNoVApsPSTbyAtB3jJq0IWTrY77WXfbPfpngxq0bA6JCEv/7k8C9qWjDRKRznDlyw=="],
 
     "@bufbuild/protobuf": ["@bufbuild/protobuf@2.12.0", "", {}, "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA=="],
 
@@ -85,7 +85,7 @@
 
     "@inquirer/external-editor": ["@inquirer/external-editor@1.0.3", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA=="],
 
-    "@laplace.live/event-bridge-sdk": ["@laplace.live/event-bridge-sdk@1.0.24", "", { "dependencies": { "@laplace.live/event-types": "^2.0.18" } }, "sha512-dxaeR8lNGdVXEekbwRPbzD1HilQdSB+P1I4WjgxCv2osBnQVMNI09LMWmEJUr4STakQuMILI5YN/as+x3ctqiA=="],
+    "@laplace.live/event-bridge-sdk": ["@laplace.live/event-bridge-sdk@1.1.0", "", { "dependencies": { "@laplace.live/event-types": "^2.0.18" } }, "sha512-cqvh8JCGmplIHed8WkzdEbPvzJMlfUWecDyBHdHyEYOAg5sWaSWB0Nsq5EjzxqPYUvpVIMka4v8ijLDVQHbeUQ=="],
 
     "@laplace.live/event-types": ["@laplace.live/event-types@2.0.18", "", { "dependencies": { "@bufbuild/protobuf": "^2.12.0", "@laplace.live/internal": "^1.3.18" }, "peerDependencies": { "typescript": "^5.9.2" } }, "sha512-G+3nNlPWNN8AtgCO9ca7Sf8OQaHQqU1ZwZM2bqMtP/tsrpfBGEA2phzCtbMqrgdT4pT6WvzGIe8GsqtCCUCq0g=="],
 

--- a/docs/superpowers/plans/2026-06-20-stream-summary.md
+++ b/docs/superpowers/plans/2026-06-20-stream-summary.md
@@ -1,0 +1,953 @@
+# Stream Summary Notification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** After a streamer's Bilibili live ends, post one end-of-stream summary notification (chat, audience, monetary, per-user highlights) to that room's Telegram channel.
+
+**Architecture:** A single new file `src/streamSummary.ts` holds three isolated units — `SessionStats` (pure in-RAM accumulator per stream), `SessionManager` (a per-room `IDLE`/`LIVE`/`ENDING` state machine with a debounce timer, robust to Bilibili's repeated lifecycle events), and `formatSummary` (pure renderer). `src/index.ts` wires one `SessionManager` into the existing event handler and emits summaries via Telegram. No database, no persistence, no new dependencies.
+
+**Tech Stack:** Bun, TypeScript (strict), `@laplace.live/event-types` (types only), `@mtcute/bun` (existing Telegram client).
+
+## Global Constraints
+
+Every task implicitly includes these (verbatim from the spec):
+
+- Runtime is **Bun**: tests run with `bun test`; typecheck with `bunx tsc`; never `node`/`jest`/`ts-node`.
+- **No database, no persistence, no new dependencies.** Metrics live in RAM and are lost on restart (accepted).
+- **No new config fields.** `src/types.ts` and `config.yaml` are unchanged; the feature is always on for every configured room.
+- Debounce default: **`STREAM_SUMMARY_DEBOUNCE_MS = 45_000`** ms.
+- Gift revenue counts **gold (paid) gifts only** (`coinType === 'gold'`).
+- New follows = `interaction.action === 2 || event.action === 4`.
+- Summary posts to **`room.telegram_announce_ch`** (same channel as the existing 开播/下播 messages).
+- Money values are `priceNormalized` (already CNY); render with thousands separators and up to 1 decimal. Counts render with thousands separators. Clock times render in **`Asia/Shanghai`**.
+- TypeScript: `strict`, `noUncheckedIndexedAccess` (Map/array access is `T | undefined` — handle it), `verbatimModuleSyntax` (type-only imports MUST use `import type`), `noFallthroughCasesInSwitch` (every `case` ends in `return`/`break`).
+
+## File Structure
+
+- `src/utils.ts` — **modify**: add `formatDuration(ms)`.
+- `src/consts.ts` — **modify**: add `STREAM_SUMMARY_DEBOUNCE_MS`.
+- `src/streamSummary.ts` — **create**: `StreamSummary` type, `SessionStats`, `formatSummary`, `SessionManager`.
+- `src/index.ts` — **modify**: instantiate `SessionManager`, route events to it, clear timers on SIGINT.
+- `src/utils.test.ts` — **create**: tests for `formatDuration`.
+- `src/streamSummary.test.ts` — **create**: tests for `SessionStats`, `formatSummary`, `SessionManager`.
+- `README.md` — **modify**: document the feature + multi-bridge caveat.
+
+---
+
+## Setup: feature branch
+
+The repo is currently on the default branch `master`. Create a working branch before Task 1.
+
+- [ ] **Step 1: Create the branch**
+
+```bash
+git checkout -b feat/stream-summary
+```
+
+---
+
+### Task 1: `formatDuration` helper
+
+**Files:**
+- Modify: `src/utils.ts`
+- Test: `src/utils.test.ts` (create)
+
+**Interfaces:**
+- Produces: `formatDuration(ms: number): string` — `"3小时42分"`, `"42分"`, `"3小时"`, `"0分"`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/utils.test.ts`:
+
+```ts
+import { expect, test } from 'bun:test'
+
+import { formatDuration } from './utils'
+
+test('formatDuration: hours and minutes', () => {
+  expect(formatDuration((3 * 60 + 42) * 60_000)).toBe('3小时42分')
+})
+
+test('formatDuration: minutes only', () => {
+  expect(formatDuration(42 * 60_000)).toBe('42分')
+})
+
+test('formatDuration: whole hours', () => {
+  expect(formatDuration(3 * 3_600_000)).toBe('3小时')
+})
+
+test('formatDuration: zero', () => {
+  expect(formatDuration(0)).toBe('0分')
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/utils.test.ts`
+Expected: FAIL — `formatDuration` is not exported from `./utils`.
+
+- [ ] **Step 3: Implement the helper**
+
+Append to `src/utils.ts`:
+
+```ts
+/** Format a duration in milliseconds as a short zh-CN string, e.g. "3小时42分". */
+export function formatDuration(ms: number): string {
+  const totalMinutes = Math.floor(ms / 60_000)
+  const hours = Math.floor(totalMinutes / 60)
+  const minutes = totalMinutes % 60
+
+  if (hours > 0 && minutes > 0) return `${hours}小时${minutes}分`
+  if (hours > 0) return `${hours}小时`
+  return `${minutes}分`
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test src/utils.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils.ts src/utils.test.ts
+git commit -m "feat: add formatDuration helper"
+```
+
+---
+
+### Task 2: `SessionStats` accumulator + `StreamSummary` type
+
+**Files:**
+- Create: `src/streamSummary.ts`
+- Test: `src/streamSummary.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `LaplaceEvent` (type) from `@laplace.live/event-types`.
+- Produces:
+  - `interface StreamSummary` with fields: `startedAt, endedAt, durationMs, partial: boolean, chats, uniqueChatters, watchedMax, onlinePeak, likesMax, newFollows: number; gifts/sc/guards: { count: number; revenue: number }; totalRevenue: number; topGifter: { uid; name; total } | null; biggestSc: { uid; name; amount; message } | null; topChatter: { uid; name; count } | null`.
+  - `class SessionStats` with `readonly startedAt: number`, `readonly partial: boolean`, constructor `(startedAt: number, partial: boolean)`, `record(event: LaplaceEvent): void`, `finalize(endedAt: number): StreamSummary`.
+  - `const RECORDABLE_TYPES: Set<string>` (used by Task 4).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/streamSummary.test.ts`:
+
+```ts
+import { expect, test } from 'bun:test'
+
+import type { LaplaceEvent } from '@laplace.live/event-types'
+
+import { SessionStats } from './streamSummary'
+
+/** Build a minimal synthetic event for tests (fields not under test are stubbed). */
+function ev(type: string, extra: Record<string, unknown>): LaplaceEvent {
+  return {
+    type,
+    id: 'x',
+    origin: 100,
+    originIdx: 0,
+    uid: 0,
+    username: 'u',
+    message: '',
+    timestamp: 0,
+    timestampNormalized: 0,
+    read: false,
+    ...extra,
+  } as unknown as LaplaceEvent
+}
+
+test('SessionStats accumulates a full event sequence', () => {
+  const stats = new SessionStats(1_000, false)
+
+  // chats: uid 1 twice, uid 2 once
+  stats.record(ev('message', { uid: 1, username: 'a' }))
+  stats.record(ev('message', { uid: 1, username: 'a' }))
+  stats.record(ev('message', { uid: 2, username: 'b' }))
+
+  // peaks / maxes (cumulative metrics)
+  stats.record(ev('watched-update', { watched: 100 }))
+  stats.record(ev('watched-update', { watched: 250 }))
+  stats.record(ev('watched-update', { watched: 200 }))
+  stats.record(ev('online-update', { online: 50 }))
+  stats.record(ev('online-update', { online: 80 }))
+  stats.record(ev('likes-update', { likes: 1_000 }))
+  stats.record(ev('likes-update', { likes: 3_000 }))
+
+  // follows: action 2 and 4 count, action 1 (enter) does not
+  stats.record(ev('interaction', { action: 2 }))
+  stats.record(ev('interaction', { action: 1 }))
+  stats.record(ev('interaction', { action: 4 }))
+
+  // gifts: gold counts, silver excluded; top gifter is uid 2
+  stats.record(ev('gift', { uid: 1, username: 'a', coinType: 'gold', priceNormalized: 10 }))
+  stats.record(ev('gift', { uid: 2, username: 'b', coinType: 'gold', priceNormalized: 30 }))
+  stats.record(ev('gift', { uid: 1, username: 'a', coinType: 'silver', priceNormalized: 5 }))
+
+  // super chats: biggest is uid 1 at 100
+  stats.record(ev('superchat', { uid: 3, username: 'c', priceNormalized: 50, message: 'hi' }))
+  stats.record(ev('superchat', { uid: 1, username: 'a', priceNormalized: 100, message: 'yo' }))
+
+  // guards
+  stats.record(ev('toast', { uid: 2, username: 'b', priceNormalized: 198 }))
+  stats.record(ev('toast', { uid: 3, username: 'c', priceNormalized: 198 }))
+
+  // ignored noise
+  stats.record(ev('room-name-update', {}))
+
+  const s = stats.finalize(1_000 + 13_320_000) // +3h42m
+
+  expect(s.durationMs).toBe(13_320_000)
+  expect(s.partial).toBe(false)
+  expect(s.chats).toBe(3)
+  expect(s.uniqueChatters).toBe(2)
+  expect(s.watchedMax).toBe(250)
+  expect(s.onlinePeak).toBe(80)
+  expect(s.likesMax).toBe(3_000)
+  expect(s.newFollows).toBe(2)
+  expect(s.gifts).toEqual({ count: 2, revenue: 40 })
+  expect(s.sc).toEqual({ count: 2, revenue: 150 })
+  expect(s.guards).toEqual({ count: 2, revenue: 396 })
+  expect(s.totalRevenue).toBe(586)
+  expect(s.topGifter).toEqual({ uid: 2, name: 'b', total: 30 })
+  expect(s.biggestSc).toEqual({ uid: 1, name: 'a', amount: 100, message: 'yo' })
+  expect(s.topChatter).toEqual({ uid: 1, name: 'a', count: 2 })
+})
+
+test('SessionStats with no activity yields empty summary', () => {
+  const s = new SessionStats(1_000, false).finalize(2_000)
+  expect(s.chats).toBe(0)
+  expect(s.uniqueChatters).toBe(0)
+  expect(s.totalRevenue).toBe(0)
+  expect(s.topGifter).toBeNull()
+  expect(s.biggestSc).toBeNull()
+  expect(s.topChatter).toBeNull()
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/streamSummary.test.ts`
+Expected: FAIL — cannot find module `./streamSummary` / `SessionStats` not exported.
+
+- [ ] **Step 3: Implement `SessionStats`**
+
+Create `src/streamSummary.ts`:
+
+```ts
+import type { LaplaceEvent } from '@laplace.live/event-types'
+
+export interface StreamSummary {
+  startedAt: number
+  endedAt: number
+  durationMs: number
+  /** true when no live-start was observed (bot started mid-stream); numbers are a lower bound. */
+  partial: boolean
+  chats: number
+  uniqueChatters: number
+  watchedMax: number
+  onlinePeak: number
+  likesMax: number
+  newFollows: number
+  gifts: { count: number; revenue: number }
+  sc: { count: number; revenue: number }
+  guards: { count: number; revenue: number }
+  totalRevenue: number
+  topGifter: { uid: number; name: string; total: number } | null
+  biggestSc: { uid: number; name: string; amount: number; message: string } | null
+  topChatter: { uid: number; name: string; count: number } | null
+}
+
+/** Event types that contribute to a stream summary. */
+export const RECORDABLE_TYPES = new Set<string>([
+  'message',
+  'watched-update',
+  'online-update',
+  'likes-update',
+  'interaction',
+  'gift',
+  'superchat',
+  'toast',
+])
+
+/** In-memory accumulator for a single live session. Pure: no I/O. */
+export class SessionStats {
+  readonly startedAt: number
+  readonly partial: boolean
+
+  private chats = 0
+  private readonly chatters = new Map<number, { name: string; count: number }>()
+  private watchedMax = 0
+  private onlinePeak = 0
+  private likesMax = 0
+  private newFollows = 0
+  private giftCount = 0
+  private giftRevenue = 0
+  private scCount = 0
+  private scRevenue = 0
+  private guardCount = 0
+  private guardRevenue = 0
+  private readonly gifters = new Map<number, { name: string; total: number }>()
+  private biggestSc: { uid: number; name: string; amount: number; message: string } | null = null
+
+  constructor(startedAt: number, partial: boolean) {
+    this.startedAt = startedAt
+    this.partial = partial
+  }
+
+  record(event: LaplaceEvent): void {
+    switch (event.type) {
+      case 'message': {
+        this.chats++
+        const c = this.chatters.get(event.uid)
+        if (c) c.count++
+        else this.chatters.set(event.uid, { name: event.username, count: 1 })
+        break
+      }
+      case 'watched-update':
+        if (event.watched > this.watchedMax) this.watchedMax = event.watched
+        break
+      case 'online-update':
+        if (event.online > this.onlinePeak) this.onlinePeak = event.online
+        break
+      case 'likes-update':
+        if (event.likes > this.likesMax) this.likesMax = event.likes
+        break
+      case 'interaction':
+        if (event.action === 2 || event.action === 4) this.newFollows++
+        break
+      case 'gift':
+        if (event.coinType === 'gold') {
+          this.giftCount++
+          this.giftRevenue += event.priceNormalized
+          const g = this.gifters.get(event.uid)
+          if (g) g.total += event.priceNormalized
+          else this.gifters.set(event.uid, { name: event.username, total: event.priceNormalized })
+        }
+        break
+      case 'superchat':
+        this.scCount++
+        this.scRevenue += event.priceNormalized
+        if (!this.biggestSc || event.priceNormalized > this.biggestSc.amount) {
+          this.biggestSc = {
+            uid: event.uid,
+            name: event.username,
+            amount: event.priceNormalized,
+            message: event.message,
+          }
+        }
+        break
+      case 'toast':
+        this.guardCount++
+        this.guardRevenue += event.priceNormalized
+        break
+      default:
+        break
+    }
+  }
+
+  finalize(endedAt: number): StreamSummary {
+    let topChatter: StreamSummary['topChatter'] = null
+    for (const [uid, v] of this.chatters) {
+      if (!topChatter || v.count > topChatter.count) {
+        topChatter = { uid, name: v.name, count: v.count }
+      }
+    }
+
+    let topGifter: StreamSummary['topGifter'] = null
+    for (const [uid, v] of this.gifters) {
+      if (!topGifter || v.total > topGifter.total) {
+        topGifter = { uid, name: v.name, total: v.total }
+      }
+    }
+
+    return {
+      startedAt: this.startedAt,
+      endedAt,
+      durationMs: Math.max(0, endedAt - this.startedAt),
+      partial: this.partial,
+      chats: this.chats,
+      uniqueChatters: this.chatters.size,
+      watchedMax: this.watchedMax,
+      onlinePeak: this.onlinePeak,
+      likesMax: this.likesMax,
+      newFollows: this.newFollows,
+      gifts: { count: this.giftCount, revenue: this.giftRevenue },
+      sc: { count: this.scCount, revenue: this.scRevenue },
+      guards: { count: this.guardCount, revenue: this.guardRevenue },
+      totalRevenue: this.giftRevenue + this.scRevenue + this.guardRevenue,
+      topGifter,
+      biggestSc: this.biggestSc,
+      topChatter,
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test src/streamSummary.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/streamSummary.ts src/streamSummary.test.ts
+git commit -m "feat: add SessionStats stream metrics accumulator"
+```
+
+---
+
+### Task 3: `formatSummary` renderer
+
+**Files:**
+- Modify: `src/streamSummary.ts`
+- Test: `src/streamSummary.test.ts` (append)
+
+**Interfaces:**
+- Consumes: `StreamSummary` (Task 2), `RoomConfig` (type) from `./types`, `formatDuration` (Task 1).
+- Produces: `formatSummary(summary: StreamSummary, room: RoomConfig): string`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/streamSummary.test.ts`:
+
+```ts
+import type { RoomConfig } from './types'
+
+import { formatSummary } from './streamSummary'
+
+const room = { slug: '测试', telegram_announce_ch: 1, telegram_watchers_ch: 1 } as unknown as RoomConfig
+
+function baseSummary(): import('./streamSummary').StreamSummary {
+  return {
+    startedAt: 0,
+    endedAt: 13_320_000,
+    durationMs: 13_320_000,
+    partial: false,
+    chats: 3,
+    uniqueChatters: 2,
+    watchedMax: 250,
+    onlinePeak: 80,
+    likesMax: 3_000,
+    newFollows: 2,
+    gifts: { count: 2, revenue: 1_240.5 },
+    sc: { count: 2, revenue: 980 },
+    guards: { count: 2, revenue: 597 },
+    totalRevenue: 2_817.5,
+    topGifter: { uid: 2, name: 'b', total: 680 },
+    biggestSc: { uid: 1, name: 'a', amount: 500, message: 'yo' },
+    topChatter: { uid: 1, name: 'a', count: 142 },
+  }
+}
+
+test('formatSummary renders all sections', () => {
+  const out = formatSummary(baseSummary(), room)
+  expect(out).toContain('#直播总结')
+  expect(out).toContain('测试')
+  expect(out).toContain('时长 3小时42分')
+  expect(out).toContain('总收入 ¥2,817.5')
+  expect(out).toContain('🎁 礼物 2 ¥1,240.5')
+  expect(out).toContain('💌 醒目留言 2 ¥980')
+  expect(out).toContain('⚓ 大航海 2 ¥597')
+  expect(out).toContain('看过 250')
+  expect(out).toContain('峰值在线 80')
+  expect(out).toContain('点赞 3,000')
+  expect(out).toContain('新增关注 2')
+  expect(out).toContain('弹幕 3')
+  expect(out).toContain('发言 2 人')
+  expect(out).toContain('最佳金主 b ¥680')
+  expect(out).toContain('最高 SC a ¥500')
+  expect(out).toContain('最活跃 a 142 条')
+})
+
+test('formatSummary omits empty sections', () => {
+  const s = baseSummary()
+  s.gifts = { count: 0, revenue: 0 }
+  s.sc = { count: 0, revenue: 0 }
+  s.guards = { count: 0, revenue: 0 }
+  s.totalRevenue = 0
+  s.topGifter = null
+  s.biggestSc = null
+  const out = formatSummary(s, room)
+  expect(out).not.toContain('总收入')
+  expect(out).not.toContain('最佳金主')
+  expect(out).not.toContain('最高 SC')
+  expect(out).toContain('#直播总结')
+  expect(out).toContain('弹幕 3')
+})
+
+test('formatSummary marks partial sessions', () => {
+  const s = baseSummary()
+  s.partial = true
+  expect(formatSummary(s, room)).toContain('⚠️ 部分数据')
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/streamSummary.test.ts`
+Expected: FAIL — `formatSummary` not exported.
+
+- [ ] **Step 3: Implement `formatSummary`**
+
+Add to `src/streamSummary.ts`. Update the top type-only import line to include `RoomConfig`, add the value import for `formatDuration`, and append the functions:
+
+```ts
+// at the top, alongside the existing imports:
+import type { RoomConfig } from './types'
+
+import { formatDuration } from './utils'
+```
+
+```ts
+// appended below SessionStats:
+
+function fmtMoney(n: number): string {
+  return n.toLocaleString('en-US', { maximumFractionDigits: 1 })
+}
+
+function fmtNum(n: number): string {
+  return n.toLocaleString('en-US')
+}
+
+function clock(ts: number): string {
+  return new Intl.DateTimeFormat('zh-CN', {
+    timeZone: 'Asia/Shanghai',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(ts)
+}
+
+/** Render a StreamSummary as a Telegram markdown message. Pure. */
+export function formatSummary(s: StreamSummary, room: RoomConfig): string {
+  const blocks: string[] = []
+
+  let header = `#直播总结 📊 ${room.slug}`
+  if (s.partial) header = `⚠️ 部分数据（监控中途启动）\n${header}`
+  blocks.push(header)
+
+  blocks.push(`🕐 时长 ${formatDuration(s.durationMs)}  ·  ${clock(s.startedAt)} → ${clock(s.endedAt)}`)
+
+  const money: string[] = []
+  if (s.gifts.count > 0) money.push(`   🎁 礼物 ${fmtNum(s.gifts.count)} ¥${fmtMoney(s.gifts.revenue)}`)
+  if (s.sc.count > 0) money.push(`   💌 醒目留言 ${fmtNum(s.sc.count)} ¥${fmtMoney(s.sc.revenue)}`)
+  if (s.guards.count > 0) money.push(`   ⚓ 大航海 ${fmtNum(s.guards.count)} ¥${fmtMoney(s.guards.revenue)}`)
+  if (money.length > 0) {
+    blocks.push([`💰 总收入 ¥${fmtMoney(s.totalRevenue)}`, ...money].join('\n'))
+  }
+
+  const audience: string[] = []
+  if (s.watchedMax > 0) audience.push(`👥 看过 ${fmtNum(s.watchedMax)}`)
+  if (s.onlinePeak > 0) audience.push(`🟢 峰值在线 ${fmtNum(s.onlinePeak)}`)
+  if (s.likesMax > 0) audience.push(`👍 点赞 ${fmtNum(s.likesMax)}`)
+  if (s.newFollows > 0) audience.push(`➕ 新增关注 ${fmtNum(s.newFollows)}`)
+  if (audience.length > 0) blocks.push(audience.join('  ·  '))
+
+  const chat: string[] = [`💬 弹幕 ${fmtNum(s.chats)}`]
+  if (s.uniqueChatters > 0) chat.push(`🗣️ 发言 ${fmtNum(s.uniqueChatters)} 人`)
+  blocks.push(chat.join('  ·  '))
+
+  const highlights: string[] = []
+  if (s.topGifter) highlights.push(`🏆 最佳金主 ${s.topGifter.name} ¥${fmtMoney(s.topGifter.total)}`)
+  if (s.biggestSc) highlights.push(`🔥 最高 SC ${s.biggestSc.name} ¥${fmtMoney(s.biggestSc.amount)}`)
+  if (s.topChatter) highlights.push(`⚡ 最活跃 ${s.topChatter.name} ${fmtNum(s.topChatter.count)} 条`)
+  if (highlights.length > 0) blocks.push(highlights.join('\n'))
+
+  return blocks.join('\n\n')
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test src/streamSummary.test.ts`
+Expected: PASS (all `streamSummary` tests, including the 3 new ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/streamSummary.ts src/streamSummary.test.ts
+git commit -m "feat: add formatSummary renderer"
+```
+
+---
+
+### Task 4: `SessionManager` lifecycle state machine
+
+**Files:**
+- Modify: `src/streamSummary.ts`
+- Test: `src/streamSummary.test.ts` (append)
+
+**Interfaces:**
+- Consumes: `SessionStats` (Task 2), `RECORDABLE_TYPES` (Task 2), `StreamSummary` (Task 2), `LaplaceEvent` (type).
+- Produces:
+  - `interface SessionManagerOptions { debounceMs: number; onSummary: (roomId: number, summary: StreamSummary) => void | Promise<void> }`
+  - `class SessionManager` with `constructor(opts: SessionManagerOptions)`, `handle(roomId: number, event: LaplaceEvent): void`, `clearAllTimers(): void`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/streamSummary.test.ts` (reuses the `ev()` helper defined in Task 2):
+
+```ts
+import { SessionManager } from './streamSummary'
+import type { StreamSummary } from './streamSummary'
+
+function makeManager() {
+  const calls: Array<{ roomId: number; summary: StreamSummary }> = []
+  const manager = new SessionManager({
+    debounceMs: 30,
+    onSummary: (roomId, summary) => {
+      calls.push({ roomId, summary })
+    },
+  })
+  return { calls, manager }
+}
+
+test('SessionManager: emits one summary after a normal stream', async () => {
+  const { calls, manager } = makeManager()
+  manager.handle(100, ev('live-start', { timestampNormalized: 1_000 }))
+  manager.handle(100, ev('message', { uid: 1, username: 'a' }))
+  manager.handle(100, ev('live-end', { timestampNormalized: 2_000 }))
+  await Bun.sleep(60)
+
+  expect(calls.length).toBe(1)
+  expect(calls[0]!.roomId).toBe(100)
+  expect(calls[0]!.summary.chats).toBe(1)
+  expect(calls[0]!.summary.endedAt).toBe(2_000)
+  expect(calls[0]!.summary.partial).toBe(false)
+})
+
+test('SessionManager: ignores duplicate live-start bursts (no reset)', async () => {
+  const { calls, manager } = makeManager()
+  manager.handle(100, ev('live-start', { timestampNormalized: 1_000 }))
+  manager.handle(100, ev('message', { uid: 1, username: 'a' }))
+  manager.handle(100, ev('live-start', { timestampNormalized: 1_001 })) // duplicate
+  manager.handle(100, ev('message', { uid: 2, username: 'b' }))
+  manager.handle(100, ev('live-end', { timestampNormalized: 2_000 }))
+  await Bun.sleep(60)
+
+  expect(calls.length).toBe(1)
+  expect(calls[0]!.summary.chats).toBe(2)
+  expect(calls[0]!.summary.startedAt).toBe(1_000)
+})
+
+test('SessionManager: collapses duplicate live-end bursts into one summary', async () => {
+  const { calls, manager } = makeManager()
+  manager.handle(100, ev('live-start', { timestampNormalized: 1_000 }))
+  manager.handle(100, ev('message', { uid: 1, username: 'a' }))
+  manager.handle(100, ev('live-end', { timestampNormalized: 2_000 }))
+  manager.handle(100, ev('live-end', { timestampNormalized: 2_001 })) // duplicate burst
+  await Bun.sleep(60)
+
+  expect(calls.length).toBe(1)
+  expect(calls[0]!.summary.endedAt).toBe(2_001)
+})
+
+test('SessionManager: a brief end->start flap is one continuous stream', async () => {
+  const { calls, manager } = makeManager()
+  manager.handle(100, ev('live-start', { timestampNormalized: 1_000 }))
+  manager.handle(100, ev('message', { uid: 1, username: 'a' }))
+  manager.handle(100, ev('live-end', { timestampNormalized: 2_000 })) // blip
+  manager.handle(100, ev('live-start', { timestampNormalized: 2_010 })) // resume within window
+  manager.handle(100, ev('message', { uid: 2, username: 'b' }))
+  manager.handle(100, ev('live-end', { timestampNormalized: 3_000 }))
+  await Bun.sleep(60)
+
+  expect(calls.length).toBe(1)
+  expect(calls[0]!.summary.chats).toBe(2)
+  expect(calls[0]!.summary.startedAt).toBe(1_000)
+  expect(calls[0]!.summary.endedAt).toBe(3_000)
+})
+
+test('SessionManager: events without a live-start produce a partial summary', async () => {
+  const { calls, manager } = makeManager()
+  manager.handle(100, ev('message', { uid: 1, username: 'a', timestampNormalized: 5_000 }))
+  manager.handle(100, ev('live-end', { timestampNormalized: 6_000 }))
+  await Bun.sleep(60)
+
+  expect(calls.length).toBe(1)
+  expect(calls[0]!.summary.partial).toBe(true)
+  expect(calls[0]!.summary.startedAt).toBe(5_000)
+})
+
+test('SessionManager: live-end with no session is ignored', async () => {
+  const { calls, manager } = makeManager()
+  manager.handle(100, ev('live-end', { timestampNormalized: 6_000 }))
+  await Bun.sleep(60)
+  expect(calls.length).toBe(0)
+})
+
+test('SessionManager: clearAllTimers cancels a pending summary', async () => {
+  const { calls, manager } = makeManager()
+  manager.handle(100, ev('live-start', { timestampNormalized: 1_000 }))
+  manager.handle(100, ev('live-end', { timestampNormalized: 2_000 }))
+  manager.clearAllTimers()
+  await Bun.sleep(60)
+  expect(calls.length).toBe(0)
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/streamSummary.test.ts`
+Expected: FAIL — `SessionManager` not exported.
+
+- [ ] **Step 3: Implement `SessionManager`**
+
+Append to `src/streamSummary.ts`:
+
+```ts
+export interface SessionManagerOptions {
+  debounceMs: number
+  onSummary: (roomId: number, summary: StreamSummary) => void | Promise<void>
+}
+
+/**
+ * Per-room lifecycle state machine for stream summaries.
+ *
+ * State is derived from two maps: a room with a session is LIVE (no timer) or
+ * ENDING (timer pending); a room with no session is IDLE. This makes the
+ * manager idempotent against Bilibili's repeated live-start/live-end events.
+ */
+export class SessionManager {
+  private readonly debounceMs: number
+  private readonly onSummary: (roomId: number, summary: StreamSummary) => void | Promise<void>
+  private readonly sessions = new Map<number, SessionStats>()
+  private readonly timers = new Map<number, ReturnType<typeof setTimeout>>()
+  private readonly pendingEndAt = new Map<number, number>()
+
+  constructor(opts: SessionManagerOptions) {
+    this.debounceMs = opts.debounceMs
+    this.onSummary = opts.onSummary
+  }
+
+  handle(roomId: number, event: LaplaceEvent): void {
+    switch (event.type) {
+      case 'live-start': {
+        const timer = this.timers.get(roomId)
+        if (timer) {
+          // ENDING -> resume: brief blip, keep counting the same session
+          clearTimeout(timer)
+          this.timers.delete(roomId)
+          this.pendingEndAt.delete(roomId)
+        } else if (!this.sessions.has(roomId)) {
+          // IDLE -> start a new session
+          this.sessions.set(roomId, new SessionStats(event.timestampNormalized, false))
+        }
+        // else LIVE duplicate -> ignore (do not reset stats)
+        return
+      }
+      case 'live-end': {
+        if (!this.sessions.has(roomId)) return // IDLE -> nothing to end
+        this.pendingEndAt.set(roomId, event.timestampNormalized)
+        const existing = this.timers.get(roomId)
+        if (existing) clearTimeout(existing)
+        this.timers.set(
+          roomId,
+          setTimeout(() => this.finalizeRoom(roomId), this.debounceMs),
+        )
+        return
+      }
+      default: {
+        if (!RECORDABLE_TYPES.has(event.type)) return
+        let session = this.sessions.get(roomId)
+        if (!session) {
+          // Bot started mid-stream: no live-start was seen -> partial session
+          session = new SessionStats(event.timestampNormalized, true)
+          this.sessions.set(roomId, session)
+        }
+        session.record(event)
+        return
+      }
+    }
+  }
+
+  /** Cancel all pending debounce timers (e.g. on shutdown). */
+  clearAllTimers(): void {
+    for (const timer of this.timers.values()) clearTimeout(timer)
+    this.timers.clear()
+  }
+
+  private finalizeRoom(roomId: number): void {
+    const session = this.sessions.get(roomId)
+    const endedAt = this.pendingEndAt.get(roomId)
+    this.timers.delete(roomId)
+    this.pendingEndAt.delete(roomId)
+    this.sessions.delete(roomId)
+    if (!session || endedAt === undefined) return
+
+    const summary = session.finalize(endedAt)
+    Promise.resolve(this.onSummary(roomId, summary)).catch(err =>
+      console.error(`[summary] onSummary failed for room ${roomId}:`, err),
+    )
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test src/streamSummary.test.ts`
+Expected: PASS (all `streamSummary` tests including the 7 new SessionManager tests).
+
+- [ ] **Step 5: Typecheck the new module**
+
+Run: `bunx tsc`
+Expected: no errors, exit code 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/streamSummary.ts src/streamSummary.test.ts
+git commit -m "feat: add SessionManager debounced lifecycle state machine"
+```
+
+---
+
+### Task 5: Wire into the bot + config const + docs
+
+**Files:**
+- Modify: `src/consts.ts`
+- Modify: `src/index.ts`
+- Modify: `README.md`
+
+**Interfaces:**
+- Consumes: `SessionManager`, `formatSummary` (Tasks 2–4); `STREAM_SUMMARY_DEBOUNCE_MS` (this task).
+- Produces: end-to-end behavior. No new exported API.
+
+This task has no unit test (it wires top-level bot startup that requires live Telegram/WebSocket credentials). It is verified by the full test suite, typecheck, lint, and a manual smoke note.
+
+- [ ] **Step 1: Add the debounce constant**
+
+Append to `src/consts.ts`:
+
+```ts
+/**
+ * Debounce window (ms) before emitting an end-of-stream summary.
+ *
+ * Bilibili fires live-start/live-end repeatedly (often several times within
+ * ~3s) and flaps end->start on brief encoder/network blips. This window
+ * collapses those bursts into a single logical stream and a single summary.
+ */
+export const STREAM_SUMMARY_DEBOUNCE_MS = 45_000
+```
+
+- [ ] **Step 2: Import the new units in `src/index.ts`**
+
+In `src/index.ts`, update the consts import (currently `import { EMOJI_MAP, GUARD_TYPE_DICT, PRICE_TIER_EMOJI, SUPERCHAT_TIER_EMOJI } from './consts'`) to also import the new constant, and add an import for the summary module after the existing `./eventStore` import:
+
+```ts
+import { EMOJI_MAP, GUARD_TYPE_DICT, PRICE_TIER_EMOJI, STREAM_SUMMARY_DEBOUNCE_MS, SUPERCHAT_TIER_EMOJI } from './consts'
+import { EventStore, formatMessagesContext } from './eventStore'
+import { SessionManager, formatSummary } from './streamSummary'
+```
+
+- [ ] **Step 3: Instantiate the SessionManager**
+
+In `src/index.ts`, immediately after the `tg` client is constructed (the `const tg = new TelegramClient({ ... })` block), add:
+
+```ts
+// Stream summary: accumulate per-room metrics and emit a summary after each stream
+const summaryManager = new SessionManager({
+  debounceMs: STREAM_SUMMARY_DEBOUNCE_MS,
+  onSummary: async (roomId, summary) => {
+    const room = roomMap.get(roomId)
+    if (!room) return
+    const message = formatSummary(summary, room)
+    try {
+      await tg.sendText(room.telegram_announce_ch, md(message), { disableWebPreview: true })
+      console.log(`[summary] Sent stream summary for ${room.slug} (${roomId})`)
+    } catch (err) {
+      console.error(`[summary] Failed to send summary for ${room.slug} (${roomId}):`, err)
+    }
+  },
+})
+```
+
+- [ ] **Step 4: Route events into the manager**
+
+In `src/index.ts`, inside `handleEvent`, after the bridge-specific skip check (the block ending `console.log(...'skipping')...return }` around line 89) and before the `// Store only message events...` block, add:
+
+```ts
+  // Accumulate metrics for the end-of-stream summary (respects the same
+  // single-bridge dedup as notifications above)
+  summaryManager.handle(roomId, event)
+```
+
+- [ ] **Step 5: Clear timers on shutdown**
+
+In `src/index.ts`, inside the `process.on('SIGINT', ...)` handler, after the `console.log('\nShutting down...')` line, add:
+
+```ts
+  // Cancel any pending summary timers (in-memory data is discarded on shutdown)
+  summaryManager.clearAllTimers()
+```
+
+- [ ] **Step 6: Verify the whole suite + types + lint**
+
+Run: `bun test`
+Expected: PASS — all tests in `src/utils.test.ts` and `src/streamSummary.test.ts`.
+
+Run: `bunx tsc`
+Expected: no errors, exit code 0.
+
+Run: `bun run lint`
+Expected: biome reports no errors. If it reports formatting issues, run `bun run format` and re-run `bun run lint`, then re-stage.
+
+- [ ] **Step 7: Document the feature in `README.md`**
+
+In `README.md`, add a bullet to the `## Features` list:
+
+```markdown
+- End-of-stream summary notifications (chat, audience, revenue, highlights)
+```
+
+And add this section immediately before `## Prerequisites`:
+
+```markdown
+## Stream Summary
+
+When a monitored stream ends, the bot posts a single summary to the room's
+`telegram_announce_ch` with the stream's duration, chat activity, audience
+(看过 / peak online / likes / new follows), monetary totals (gifts, super
+chats, 大航海), and per-user highlights (top gifter, biggest super chat, most
+active chatter).
+
+Metrics are accumulated **in memory** — there is no database, and an in-progress
+stream's totals are lost if the process restarts. Bilibili fires
+`live-start`/`live-end` repeatedly and flaps on brief drops, so the summary is
+sent after a debounce window (`STREAM_SUMMARY_DEBOUNCE_MS`, default 45s) once the
+stream has truly ended.
+
+> **Multi-bridge note:** counts assume each room is pinned to a single `bridge`.
+> If a room is monitored by multiple bridges, duplicate events will inflate the
+> summary — pin the room to one bridge (as you already do to avoid duplicate
+> notifications).
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/consts.ts src/index.ts README.md
+git commit -m "feat: emit end-of-stream summary notifications"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- In-memory, no DB, no persistence → `SessionStats` (RAM only); no storage code. ✅
+- No new config fields → `types.ts`/`config.yaml` untouched; debounce is a const. ✅
+- Debounce 45s + robust to repeated live-start/live-end → `SessionManager` state machine + `STREAM_SUMMARY_DEBOUNCE_MS`; Task 4 tests cover burst dedup, continuation, single-emit. ✅
+- Metrics: monetary / audience / chat / highlights + duration → `SessionStats.record`/`finalize`; Task 2 test asserts all. ✅
+- Gold-only gift revenue; follows = action 2/4 → implemented and asserted. ✅
+- Summary to `telegram_announce_ch`; project style → `formatSummary` + Task 5 onSummary. ✅
+- Partial (mid-stream start) labeled → `partial` flag, `⚠️` marker; Task 3 + Task 4 tests. ✅
+- SIGINT clears timers → Task 5 Step 5. ✅
+- Multi-bridge caveat + deleted-SC limitation → README (Task 5) / accepted in spec. ✅
+
+**Placeholder scan:** No TBD/TODO; every code step contains full code; every command has expected output. ✅
+
+**Type consistency:** `handle()`, `clearAllTimers()`, `record()`, `finalize()`, `formatSummary()`, `formatDuration()`, `StreamSummary`, `SessionManagerOptions`, `RECORDABLE_TYPES`, `STREAM_SUMMARY_DEBOUNCE_MS` are used with identical names/signatures across tasks and call sites. `onSummary(roomId, summary)` matches between `SessionManager` and the `index.ts` callback. ✅

--- a/docs/superpowers/plans/2026-06-20-stream-summary.md
+++ b/docs/superpowers/plans/2026-06-20-stream-summary.md
@@ -884,16 +884,24 @@ In `src/index.ts`, inside the `process.on('SIGINT', ...)` handler, after the `co
   summaryManager.clearAllTimers()
 ```
 
-- [ ] **Step 6: Verify the whole suite + types + lint**
+- [ ] **Step 6: Align tsconfig, then verify the whole suite + types + lint**
+
+First make `tsc` a clean gate. The `references/` directory holds scratch reference scripts that are **not** part of the build (the Dockerfile copies only `src/`) and carry pre-existing type errors. Biome already excludes it (`biome.jsonc` `includes` has `!references`) but `tsconfig.json` does not, so a bare `bunx tsc` fails on that pre-existing noise. Add a matching `exclude` as a sibling of `compilerOptions` in `tsconfig.json` (the file currently has only a `compilerOptions` object — add the new top-level key after it):
+
+```jsonc
+  "exclude": ["node_modules", "references"]
+```
+
+Then run, in order:
 
 Run: `bun test`
 Expected: PASS — all tests in `src/utils.test.ts` and `src/streamSummary.test.ts`.
 
 Run: `bunx tsc`
-Expected: no errors, exit code 0.
+Expected: no errors, exit code 0 (`references/` is now excluded; `src/` was already clean).
 
 Run: `bun run lint`
-Expected: biome reports no errors. If it reports formatting issues, run `bun run format` and re-run `bun run lint`, then re-stage.
+Expected: Biome reports no errors. Tasks 3–4 appended `import` lines mid-file in `src/streamSummary.test.ts`; if Biome flags import organization or formatting, run `bun run format`, then re-run `bun run lint`, and re-stage.
 
 - [ ] **Step 7: Document the feature in `README.md`**
 
@@ -929,7 +937,7 @@ stream has truly ended.
 - [ ] **Step 8: Commit**
 
 ```bash
-git add src/consts.ts src/index.ts README.md
+git add src/consts.ts src/index.ts tsconfig.json README.md
 git commit -m "feat: emit end-of-stream summary notifications"
 ```
 

--- a/docs/superpowers/specs/2026-06-20-stream-summary-design.md
+++ b/docs/superpowers/specs/2026-06-20-stream-summary-design.md
@@ -1,0 +1,179 @@
+# Stream Summary Notification — Design
+
+**Date:** 2026-06-20
+**Status:** Approved
+**Component:** `laplace-jupiter`
+
+## Goal
+
+After a streamer's Bilibili live ends, post a single end-of-stream **summary
+notification** to that room's Telegram channel, reporting metrics accumulated
+over the whole stream: chat, audience, monetary income, and per-user
+highlights.
+
+## Key decisions
+
+- **No database, no persistence.** Metrics are counts/sums/maxes, so they are
+  accumulated in RAM per room (a sibling of the existing in-memory
+  `EventStore`). A process restart loses the in-progress stream's totals — this
+  is an accepted trade-off in exchange for simplicity.
+- **No new configuration.** The feature is always on for every room already in
+  `config.yaml`. No per-room opt-in flag. `types.ts` and `config.yaml` are
+  unchanged.
+- **Debounced end.** Bilibili fires `live-start`/`live-end` repeatedly (often
+  several times within ~3 seconds) and also flaps end→start on brief encoder /
+  network blips. A 45-second debounce plus an explicit state machine collapses
+  these bursts into one logical stream and one summary.
+
+## Metrics captured
+
+Always: **stream duration** + start/end timestamps.
+
+- **Monetary** — gift count + revenue (gold/paid gifts only), super chat count
+  + revenue, 大航海/guard count + revenue, and grand total revenue
+  (gift + sc + guard).
+- **Audience** — 看过 (`watched-update.watched`, peak), peak online
+  (`online-update.online`), total likes (`likes-update.likes`, peak), new
+  follows (`interaction.action === 2 || === 4`).
+- **Chat activity** — total danmaku count, unique chatter count.
+- **Highlights (per-user)** — top gifter, biggest single super chat, most
+  active chatter.
+
+## Architecture
+
+One new file, **`src/streamSummary.ts`**, following the existing
+`eventStore.ts` convention (class + helper in one file). It exports three
+isolated units:
+
+| Unit | Responsibility | I/O |
+|------|----------------|-----|
+| `SessionStats` | Pure accumulator for one stream. `record(event)` mutates counters; `finalize(endedAt)` returns a plain `StreamSummary`. | none — pure, unit-testable |
+| `SessionManager` | Owns `Map<roomId, SessionStats>` and `Map<roomId, Timer>`. Drives the lifecycle state machine. Calls an injected `onSummary(roomId, summary)` callback. | timers only |
+| `formatSummary(summary, roomCfg)` | Pure function → Telegram markdown string. | none — pure, testable |
+
+`src/index.ts` instantiates one `SessionManager` whose `onSummary` callback
+reuses the existing `sender()` to post to the room's `telegram_announce_ch`
+(same channel as the current 开播/下播 messages). Telegram concerns stay out of
+the stats logic so it can be tested without a bot or WebSocket.
+
+A small `formatDuration(ms)` helper is added to `src/utils.ts`. A
+`STREAM_SUMMARY_DEBOUNCE_MS = 45_000` const is added to `src/consts.ts`.
+
+### `SessionStats` data model
+
+```
+startedAt / endedAt / partial            // partial=true if no live-start was seen (bot started mid-stream)
+chats                                     // count of `message` events
+chatters: Map<uid, {name, count}>        // .size = unique chatters; max by count = most active chatter
+watchedMax / onlinePeak / likesMax       // running max of watched-update / online-update / likes-update
+newFollows                               // count of interaction.action === 2 || === 4
+gifts:  {count, revenue}                 // `gift` where coinType === 'gold' (paid only)
+sc:     {count, revenue}                 // `superchat`
+guards: {count, revenue}                 // `toast`
+gifters: Map<uid, {name, total}>         // max by total = top gifter
+biggestSc: {uid, name, amount, message}  // running max single super chat
+```
+
+Grand total revenue = `gifts.revenue + sc.revenue + guards.revenue`. The two
+`Map`s are the only non-trivial memory and are acceptable in RAM (the existing
+`EventStore` already holds up to 6000 full message objects per room).
+
+**`record(event)`** switches on `event.type`:
+- `message` → `chats++`; upsert `chatters[uid]`.
+- `watched-update` → `watchedMax = max(watchedMax, watched)`.
+- `online-update` → `onlinePeak = max(onlinePeak, online)`.
+- `likes-update` → `likesMax = max(likesMax, likes)`.
+- `interaction` with `action === 2 || action === 4` → `newFollows++`.
+- `gift` with `coinType === 'gold'` → `gifts.count++`, `gifts.revenue += priceNormalized`; upsert `gifters[uid]`.
+- `superchat` → `sc.count++`, `sc.revenue += priceNormalized`; update `biggestSc` if larger.
+- `toast` → `guards.count++`, `guards.revenue += priceNormalized`.
+
+All other event types are ignored by the accumulator.
+
+## Lifecycle state machine
+
+Per room, state is one of `IDLE`, `LIVE`, `ENDING`. This is what makes the
+feature robust to Bilibili's repeated/duplicate lifecycle events.
+
+| State | Event | Action | Next state |
+|-------|-------|--------|------------|
+| `IDLE` | `live-start` | create `SessionStats` | `LIVE` |
+| `IDLE` | mid-stream event (no start seen) | lazily create `SessionStats` with `partial=true` | `LIVE` |
+| `IDLE` | `live-end` | ignore (no session) | `IDLE` |
+| `LIVE` | `live-start` (duplicate burst) | **ignore** — do not reset stats | `LIVE` |
+| `LIVE` | recordable event | `stats.record(event)` | `LIVE` |
+| `LIVE` | `live-end` | set `pendingEndAt = event.timestampNormalized`; start 45s timer | `ENDING` |
+| `ENDING` | `live-end` (duplicate burst) | update `pendingEndAt`; **restart** 45s timer | `ENDING` |
+| `ENDING` | `live-start` (resume within window) | **cancel timer**; keep stats (continuation) | `LIVE` |
+| `ENDING` | recordable event | `stats.record(event)` (still counts) | `ENDING` |
+| `ENDING` | timer fires | `finalize(pendingEndAt)` → `onSummary` → delete session | `IDLE` |
+
+Consequences:
+- Multiple `live-start` within ~3s → first enters `LIVE`, the rest are ignored.
+- Multiple `live-end` within ~3s → timer keeps resetting; exactly one summary
+  fires ~45s after the last `live-end`.
+- A brief end→start flap (encoder restart) → the `live-start` cancels the timer;
+  one continuous stream, one summary.
+- **End time is the `live-end` timestamp**, not the (45s-later) moment the timer
+  fires.
+
+## Summary message (illustrative wording, tweakable)
+
+Markdown, project hashtag+emoji style, posted to `telegram_announce_ch`. Empty
+sections (e.g. no super chats) are omitted.
+
+```
+#直播总结 📊 明前奶绿
+
+🕐 时长 3小时42分  ·  19:00 → 22:42
+
+💰 总收入 ¥2,817.5
+   🎁 礼物 87 ¥1,240.5
+   💌 醒目留言 12 ¥980
+   ⚓ 大航海 3 ¥597
+
+👥 看过 18,650  ·  🟢 峰值在线 3,420
+👍 点赞 95,000  ·  ➕ 新增关注 233
+💬 弹幕 4,213  ·  🗣️ 发言 892 人
+
+🏆 最佳金主 @xxx ¥680
+🔥 最高 SC @yyy ¥500
+⚡ 最活跃 @zzz 142 条
+```
+
+A `partial` summary is prefixed with a marker (e.g. `⚠️ 部分数据（监控中途启动）`)
+and omits/adjusts duration since the true start is unknown.
+
+## Edge cases & limitations
+
+- **Bot starts mid-stream** (no `live-start` seen): events lazily create a
+  `partial` session; the summary is still sent, clearly labeled, using the first
+  recorded event's time as a lower-bound start.
+- **Multi-bridge duplicates**: counts assume the room is pinned to a single
+  `bridge` (the same constraint the current setup already relies on to avoid
+  duplicate notifications). Noted in README.
+- **Deleted super chats**: counted at receive time; later deletions
+  (`superchat-delete`) are not subtracted. Rare; accepted.
+- **Graceful shutdown** (SIGINT): clear all pending debounce timers; no summary
+  is emitted on a deliberate shutdown (in-memory data is discarded, as accepted).
+
+## Files touched
+
+- **new** `src/streamSummary.ts` — `SessionStats`, `SessionManager`, `formatSummary`, types.
+- `src/consts.ts` — add `STREAM_SUMMARY_DEBOUNCE_MS` (+ any summary emoji).
+- `src/utils.ts` — add `formatDuration(ms)`.
+- `src/index.ts` — instantiate `SessionManager`; route events to
+  `record`/`onLiveStart`/`onLiveEnd`; clear timers on SIGINT.
+- `README.md` — document the feature + multi-bridge caveat.
+- `types.ts` / `config.yaml` — **unchanged**.
+
+## Testing
+
+`bun test` against the pure units (no network):
+- `SessionStats`: feed a synthetic event sequence, assert `finalize()` totals,
+  unique-chatter count, top gifter, biggest SC, peak/max values.
+- `formatSummary`: assert rendered output and section omission.
+- `SessionManager`: drive the state machine with injected timer control + a spy
+  `onSummary` to verify burst dedup, continuation, and single-emit behavior.
+
+No Telegram or WebSocket required.

--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
     "release": "changeset tag"
   },
   "dependencies": {
-    "@laplace.live/event-bridge-sdk": "^1.0.24",
+    "@laplace.live/event-bridge-sdk": "^1.1.0",
     "@mtcute/bun": "0.29.7"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.4.15",
+    "@biomejs/biome": "^2.5.0",
     "@changesets/cli": "^2.31.0",
     "@types/bun": "^1.3.14"
   },

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -89,3 +89,12 @@ export function SUPERCHAT_TIER_EMOJI(price: number): string {
   if (price >= 30) return '🟦'
   return ''
 }
+
+/**
+ * Debounce window (ms) before emitting an end-of-stream summary.
+ *
+ * Bilibili fires live-start/live-end repeatedly (often several times within
+ * ~3s) and flaps end->start on brief encoder/network blips. This window
+ * collapses those bursts into a single logical stream and a single summary.
+ */
+export const STREAM_SUMMARY_DEBOUNCE_MS = 45_000

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,7 @@ const summaryManager = new SessionManager({
   onSummary: async (roomId, summary) => {
     const room = roomMap.get(roomId)
     if (!room) return
-    const message = formatSummary(summary, room)
+    const message = formatSummary(summary, room, md.escape)
     try {
       await tg.sendText(room.telegram_announce_ch, md(message), { disableWebPreview: true })
       console.log(`[summary] Sent stream summary for ${room.slug} (${roomId})`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,8 +7,15 @@ import { md } from '@mtcute/markdown-parser'
 import type { EventBridgeConfig, RoomConfig } from './types'
 
 import config from '../config.yaml'
-import { EMOJI_MAP, GUARD_TYPE_DICT, PRICE_TIER_EMOJI, SUPERCHAT_TIER_EMOJI } from './consts'
+import {
+  EMOJI_MAP,
+  GUARD_TYPE_DICT,
+  PRICE_TIER_EMOJI,
+  STREAM_SUMMARY_DEBOUNCE_MS,
+  SUPERCHAT_TIER_EMOJI,
+} from './consts'
 import { EventStore, formatMessagesContext } from './eventStore'
+import { formatSummary, SessionManager } from './streamSummary'
 import { timeFromNow } from './utils'
 
 // Load configuration
@@ -45,6 +52,22 @@ const tg = new TelegramClient({
   apiId: Number(process.env.TELEGRAM_API_ID),
   apiHash: process.env.TELEGRAM_API_HASH,
   storage: `${botDataDir}/session`,
+})
+
+// Stream summary: accumulate per-room metrics and emit a summary after each stream
+const summaryManager = new SessionManager({
+  debounceMs: STREAM_SUMMARY_DEBOUNCE_MS,
+  onSummary: async (roomId, summary) => {
+    const room = roomMap.get(roomId)
+    if (!room) return
+    const message = formatSummary(summary, room)
+    try {
+      await tg.sendText(room.telegram_announce_ch, md(message), { disableWebPreview: true })
+      console.log(`[summary] Sent stream summary for ${room.slug} (${roomId})`)
+    } catch (err) {
+      console.error(`[summary] Failed to send summary for ${room.slug} (${roomId}):`, err)
+    }
+  },
 })
 
 // Create event bridge clients
@@ -87,6 +110,10 @@ const handleEvent = async (event: LaplaceEvent, bridge: EventBridgeConfig) => {
     console.log(`[${bridgeName}] Room ${roomId} is configured for bridge '${roomCfg.bridge}', skipping`)
     return
   }
+
+  // Accumulate metrics for the end-of-stream summary (respects the same
+  // single-bridge dedup as notifications above)
+  summaryManager.handle(roomId, event)
 
   // Store only message events in room-specific EventStore (for context feature)
   if (event.type === 'message') {
@@ -371,6 +398,9 @@ async function start() {
 // Graceful shutdown
 process.on('SIGINT', async () => {
   console.log('\nShutting down...')
+
+  // Cancel any pending summary timers (in-memory data is discarded on shutdown)
+  summaryManager.clearAllTimers()
 
   // Disconnect all event bridges
   for (const { name, client } of clients) {

--- a/src/streamSummary.test.ts
+++ b/src/streamSummary.test.ts
@@ -157,3 +157,100 @@ test('formatSummary marks partial sessions', () => {
   s.partial = true
   expect(formatSummary(s, room)).toContain('⚠️ 部分数据')
 })
+
+import { SessionManager } from './streamSummary'
+import type { StreamSummary } from './streamSummary'
+
+function makeManager() {
+  const calls: Array<{ roomId: number; summary: StreamSummary }> = []
+  const manager = new SessionManager({
+    debounceMs: 30,
+    onSummary: (roomId, summary) => {
+      calls.push({ roomId, summary })
+    },
+  })
+  return { calls, manager }
+}
+
+test('SessionManager: emits one summary after a normal stream', async () => {
+  const { calls, manager } = makeManager()
+  manager.handle(100, ev('live-start', { timestampNormalized: 1_000 }))
+  manager.handle(100, ev('message', { uid: 1, username: 'a' }))
+  manager.handle(100, ev('live-end', { timestampNormalized: 2_000 }))
+  await Bun.sleep(60)
+
+  expect(calls.length).toBe(1)
+  expect(calls[0]!.roomId).toBe(100)
+  expect(calls[0]!.summary.chats).toBe(1)
+  expect(calls[0]!.summary.endedAt).toBe(2_000)
+  expect(calls[0]!.summary.partial).toBe(false)
+})
+
+test('SessionManager: ignores duplicate live-start bursts (no reset)', async () => {
+  const { calls, manager } = makeManager()
+  manager.handle(100, ev('live-start', { timestampNormalized: 1_000 }))
+  manager.handle(100, ev('message', { uid: 1, username: 'a' }))
+  manager.handle(100, ev('live-start', { timestampNormalized: 1_001 })) // duplicate
+  manager.handle(100, ev('message', { uid: 2, username: 'b' }))
+  manager.handle(100, ev('live-end', { timestampNormalized: 2_000 }))
+  await Bun.sleep(60)
+
+  expect(calls.length).toBe(1)
+  expect(calls[0]!.summary.chats).toBe(2)
+  expect(calls[0]!.summary.startedAt).toBe(1_000)
+})
+
+test('SessionManager: collapses duplicate live-end bursts into one summary', async () => {
+  const { calls, manager } = makeManager()
+  manager.handle(100, ev('live-start', { timestampNormalized: 1_000 }))
+  manager.handle(100, ev('message', { uid: 1, username: 'a' }))
+  manager.handle(100, ev('live-end', { timestampNormalized: 2_000 }))
+  manager.handle(100, ev('live-end', { timestampNormalized: 2_001 })) // duplicate burst
+  await Bun.sleep(60)
+
+  expect(calls.length).toBe(1)
+  expect(calls[0]!.summary.endedAt).toBe(2_001)
+})
+
+test('SessionManager: a brief end->start flap is one continuous stream', async () => {
+  const { calls, manager } = makeManager()
+  manager.handle(100, ev('live-start', { timestampNormalized: 1_000 }))
+  manager.handle(100, ev('message', { uid: 1, username: 'a' }))
+  manager.handle(100, ev('live-end', { timestampNormalized: 2_000 })) // blip
+  manager.handle(100, ev('live-start', { timestampNormalized: 2_010 })) // resume within window
+  manager.handle(100, ev('message', { uid: 2, username: 'b' }))
+  manager.handle(100, ev('live-end', { timestampNormalized: 3_000 }))
+  await Bun.sleep(60)
+
+  expect(calls.length).toBe(1)
+  expect(calls[0]!.summary.chats).toBe(2)
+  expect(calls[0]!.summary.startedAt).toBe(1_000)
+  expect(calls[0]!.summary.endedAt).toBe(3_000)
+})
+
+test('SessionManager: events without a live-start produce a partial summary', async () => {
+  const { calls, manager } = makeManager()
+  manager.handle(100, ev('message', { uid: 1, username: 'a', timestampNormalized: 5_000 }))
+  manager.handle(100, ev('live-end', { timestampNormalized: 6_000 }))
+  await Bun.sleep(60)
+
+  expect(calls.length).toBe(1)
+  expect(calls[0]!.summary.partial).toBe(true)
+  expect(calls[0]!.summary.startedAt).toBe(5_000)
+})
+
+test('SessionManager: live-end with no session is ignored', async () => {
+  const { calls, manager } = makeManager()
+  manager.handle(100, ev('live-end', { timestampNormalized: 6_000 }))
+  await Bun.sleep(60)
+  expect(calls.length).toBe(0)
+})
+
+test('SessionManager: clearAllTimers cancels a pending summary', async () => {
+  const { calls, manager } = makeManager()
+  manager.handle(100, ev('live-start', { timestampNormalized: 1_000 }))
+  manager.handle(100, ev('live-end', { timestampNormalized: 2_000 }))
+  manager.clearAllTimers()
+  await Bun.sleep(60)
+  expect(calls.length).toBe(0)
+})

--- a/src/streamSummary.test.ts
+++ b/src/streamSummary.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'bun:test'
 import type { LaplaceEvent } from '@laplace.live/event-types'
+import { md } from '@mtcute/markdown-parser'
 
 import { SessionStats } from './streamSummary'
 
@@ -73,7 +74,7 @@ test('SessionStats accumulates a full event sequence', () => {
   expect(s.guards).toEqual({ count: 2, revenue: 396 })
   expect(s.totalRevenue).toBe(586)
   expect(s.topGifter).toEqual({ uid: 2, name: 'b', total: 30 })
-  expect(s.biggestSc).toEqual({ uid: 1, name: 'a', amount: 100 })
+  expect(s.biggestSc).toEqual({ uid: 1, name: 'a', amount: 100, message: 'yo' })
   expect(s.topChatter).toEqual({ uid: 1, name: 'a', count: 2 })
 })
 
@@ -110,7 +111,7 @@ function baseSummary(): import('./streamSummary').StreamSummary {
     guards: { count: 2, revenue: 597 },
     totalRevenue: 2_817.5,
     topGifter: { uid: 2, name: 'b', total: 680 },
-    biggestSc: { uid: 1, name: 'a', amount: 500 },
+    biggestSc: { uid: 1, name: 'a', amount: 500, message: 'gg' },
     topChatter: { uid: 1, name: 'a', count: 142 },
   }
 }
@@ -131,7 +132,7 @@ test('formatSummary renders all sections', () => {
   expect(out).toContain('弹幕 3')
   expect(out).toContain('发言 2 人')
   expect(out).toContain('最佳金主 b ¥680')
-  expect(out).toContain('最高 SC a ¥500')
+  expect(out).toContain('最高 SC a ¥500: gg')
   expect(out).toContain('最活跃 a 142 条')
 })
 
@@ -155,6 +156,24 @@ test('formatSummary marks partial sessions', () => {
   const s = baseSummary()
   s.partial = true
   expect(formatSummary(s, room)).toContain('⚠️ 部分数据')
+})
+
+test('formatSummary applies the escaper to viewer-supplied name/message fields', () => {
+  const s = baseSummary()
+  s.biggestSc = { uid: 1, name: 'a', amount: 500, message: 'hi' }
+  const out = formatSummary(s, room, t => `⟦${t}⟧`)
+  expect(out).toContain('最高 SC ⟦a⟧ ¥500: ⟦hi⟧')
+  expect(out).toContain('最佳金主 ⟦b⟧')
+  expect(out).toContain('最活跃 ⟦a⟧')
+  expect(out).toContain('¥680') // amounts are not escaped
+})
+
+test('formatSummary output stays valid markdown even with hostile text', () => {
+  const s = baseSummary()
+  s.biggestSc = { uid: 1, name: '[a](x)', amount: 500, message: 'gg `unbalanced' }
+  s.topGifter = { uid: 2, name: '**b', total: 680 }
+  const out = formatSummary(s, room, md.escape)
+  expect(() => md(out)).not.toThrow()
 })
 
 import type { StreamSummary } from './streamSummary'

--- a/src/streamSummary.test.ts
+++ b/src/streamSummary.test.ts
@@ -1,5 +1,4 @@
 import { expect, test } from 'bun:test'
-
 import type { LaplaceEvent } from '@laplace.live/event-types'
 
 import { SessionStats } from './streamSummary'
@@ -158,8 +157,9 @@ test('formatSummary marks partial sessions', () => {
   expect(formatSummary(s, room)).toContain('⚠️ 部分数据')
 })
 
-import { SessionManager } from './streamSummary'
 import type { StreamSummary } from './streamSummary'
+
+import { SessionManager } from './streamSummary'
 
 function makeManager() {
   const calls: Array<{ roomId: number; summary: StreamSummary }> = []

--- a/src/streamSummary.test.ts
+++ b/src/streamSummary.test.ts
@@ -73,7 +73,7 @@ test('SessionStats accumulates a full event sequence', () => {
   expect(s.guards).toEqual({ count: 2, revenue: 396 })
   expect(s.totalRevenue).toBe(586)
   expect(s.topGifter).toEqual({ uid: 2, name: 'b', total: 30 })
-  expect(s.biggestSc).toEqual({ uid: 1, name: 'a', amount: 100, message: 'yo' })
+  expect(s.biggestSc).toEqual({ uid: 1, name: 'a', amount: 100 })
   expect(s.topChatter).toEqual({ uid: 1, name: 'a', count: 2 })
 })
 
@@ -110,7 +110,7 @@ function baseSummary(): import('./streamSummary').StreamSummary {
     guards: { count: 2, revenue: 597 },
     totalRevenue: 2_817.5,
     topGifter: { uid: 2, name: 'b', total: 680 },
-    biggestSc: { uid: 1, name: 'a', amount: 500, message: 'yo' },
+    biggestSc: { uid: 1, name: 'a', amount: 500 },
     topChatter: { uid: 1, name: 'a', count: 142 },
   }
 }
@@ -253,4 +253,43 @@ test('SessionManager: clearAllTimers cancels a pending summary', async () => {
   manager.clearAllTimers()
   await Bun.sleep(60)
   expect(calls.length).toBe(0)
+})
+
+test('SessionManager: handles the SDK firing live-start twice on a real start', async () => {
+  // Bilibili always fires live-start twice at the start of a stream
+  // (see @laplace.live/event-types live-start.ts: "开播事件必会触发两次").
+  const { calls, manager } = makeManager()
+  manager.handle(100, ev('live-start', { timestampNormalized: 1_000, initial: true }))
+  manager.handle(100, ev('live-start', { timestampNormalized: 1_002 })) // second fire, no initial
+  manager.handle(100, ev('message', { uid: 1, username: 'a' }))
+  manager.handle(100, ev('live-end', { timestampNormalized: 2_000 }))
+  await Bun.sleep(60)
+
+  expect(calls.length).toBe(1)
+  expect(calls[0]!.summary.chats).toBe(1)
+  expect(calls[0]!.summary.startedAt).toBe(1_000) // first fire wins, no reset
+})
+
+test('SessionManager: keeps sequential streams in the same room independent', async () => {
+  const { calls, manager } = makeManager()
+
+  // Stream A
+  manager.handle(100, ev('live-start', { timestampNormalized: 1_000 }))
+  manager.handle(100, ev('message', { uid: 1, username: 'a' }))
+  manager.handle(100, ev('message', { uid: 2, username: 'b' }))
+  manager.handle(100, ev('live-end', { timestampNormalized: 2_000 }))
+  await Bun.sleep(60)
+
+  // Stream B in the same room, after A finalized
+  manager.handle(100, ev('live-start', { timestampNormalized: 3_000 }))
+  manager.handle(100, ev('message', { uid: 3, username: 'c' }))
+  manager.handle(100, ev('live-end', { timestampNormalized: 4_000 }))
+  await Bun.sleep(60)
+
+  expect(calls.length).toBe(2)
+  expect(calls[0]!.summary.chats).toBe(2)
+  expect(calls[0]!.summary.startedAt).toBe(1_000)
+  expect(calls[1]!.summary.chats).toBe(1) // not polluted by stream A
+  expect(calls[1]!.summary.startedAt).toBe(3_000)
+  expect(calls[1]!.summary.endedAt).toBe(4_000)
 })

--- a/src/streamSummary.test.ts
+++ b/src/streamSummary.test.ts
@@ -1,0 +1,89 @@
+import { expect, test } from 'bun:test'
+
+import type { LaplaceEvent } from '@laplace.live/event-types'
+
+import { SessionStats } from './streamSummary'
+
+/** Build a minimal synthetic event for tests (fields not under test are stubbed). */
+function ev(type: string, extra: Record<string, unknown>): LaplaceEvent {
+  return {
+    type,
+    id: 'x',
+    origin: 100,
+    originIdx: 0,
+    uid: 0,
+    username: 'u',
+    message: '',
+    timestamp: 0,
+    timestampNormalized: 0,
+    read: false,
+    ...extra,
+  } as unknown as LaplaceEvent
+}
+
+test('SessionStats accumulates a full event sequence', () => {
+  const stats = new SessionStats(1_000, false)
+
+  // chats: uid 1 twice, uid 2 once
+  stats.record(ev('message', { uid: 1, username: 'a' }))
+  stats.record(ev('message', { uid: 1, username: 'a' }))
+  stats.record(ev('message', { uid: 2, username: 'b' }))
+
+  // peaks / maxes (cumulative metrics)
+  stats.record(ev('watched-update', { watched: 100 }))
+  stats.record(ev('watched-update', { watched: 250 }))
+  stats.record(ev('watched-update', { watched: 200 }))
+  stats.record(ev('online-update', { online: 50 }))
+  stats.record(ev('online-update', { online: 80 }))
+  stats.record(ev('likes-update', { likes: 1_000 }))
+  stats.record(ev('likes-update', { likes: 3_000 }))
+
+  // follows: action 2 and 4 count, action 1 (enter) does not
+  stats.record(ev('interaction', { action: 2 }))
+  stats.record(ev('interaction', { action: 1 }))
+  stats.record(ev('interaction', { action: 4 }))
+
+  // gifts: gold counts, silver excluded; top gifter is uid 2
+  stats.record(ev('gift', { uid: 1, username: 'a', coinType: 'gold', priceNormalized: 10 }))
+  stats.record(ev('gift', { uid: 2, username: 'b', coinType: 'gold', priceNormalized: 30 }))
+  stats.record(ev('gift', { uid: 1, username: 'a', coinType: 'silver', priceNormalized: 5 }))
+
+  // super chats: biggest is uid 1 at 100
+  stats.record(ev('superchat', { uid: 3, username: 'c', priceNormalized: 50, message: 'hi' }))
+  stats.record(ev('superchat', { uid: 1, username: 'a', priceNormalized: 100, message: 'yo' }))
+
+  // guards
+  stats.record(ev('toast', { uid: 2, username: 'b', priceNormalized: 198 }))
+  stats.record(ev('toast', { uid: 3, username: 'c', priceNormalized: 198 }))
+
+  // ignored noise
+  stats.record(ev('room-name-update', {}))
+
+  const s = stats.finalize(1_000 + 13_320_000) // +3h42m
+
+  expect(s.durationMs).toBe(13_320_000)
+  expect(s.partial).toBe(false)
+  expect(s.chats).toBe(3)
+  expect(s.uniqueChatters).toBe(2)
+  expect(s.watchedMax).toBe(250)
+  expect(s.onlinePeak).toBe(80)
+  expect(s.likesMax).toBe(3_000)
+  expect(s.newFollows).toBe(2)
+  expect(s.gifts).toEqual({ count: 2, revenue: 40 })
+  expect(s.sc).toEqual({ count: 2, revenue: 150 })
+  expect(s.guards).toEqual({ count: 2, revenue: 396 })
+  expect(s.totalRevenue).toBe(586)
+  expect(s.topGifter).toEqual({ uid: 2, name: 'b', total: 30 })
+  expect(s.biggestSc).toEqual({ uid: 1, name: 'a', amount: 100, message: 'yo' })
+  expect(s.topChatter).toEqual({ uid: 1, name: 'a', count: 2 })
+})
+
+test('SessionStats with no activity yields empty summary', () => {
+  const s = new SessionStats(1_000, false).finalize(2_000)
+  expect(s.chats).toBe(0)
+  expect(s.uniqueChatters).toBe(0)
+  expect(s.totalRevenue).toBe(0)
+  expect(s.topGifter).toBeNull()
+  expect(s.biggestSc).toBeNull()
+  expect(s.topChatter).toBeNull()
+})

--- a/src/streamSummary.test.ts
+++ b/src/streamSummary.test.ts
@@ -87,3 +87,73 @@ test('SessionStats with no activity yields empty summary', () => {
   expect(s.biggestSc).toBeNull()
   expect(s.topChatter).toBeNull()
 })
+
+import type { RoomConfig } from './types'
+
+import { formatSummary } from './streamSummary'
+
+const room = { slug: '测试', telegram_announce_ch: 1, telegram_watchers_ch: 1 } as unknown as RoomConfig
+
+function baseSummary(): import('./streamSummary').StreamSummary {
+  return {
+    startedAt: 0,
+    endedAt: 13_320_000,
+    durationMs: 13_320_000,
+    partial: false,
+    chats: 3,
+    uniqueChatters: 2,
+    watchedMax: 250,
+    onlinePeak: 80,
+    likesMax: 3_000,
+    newFollows: 2,
+    gifts: { count: 2, revenue: 1_240.5 },
+    sc: { count: 2, revenue: 980 },
+    guards: { count: 2, revenue: 597 },
+    totalRevenue: 2_817.5,
+    topGifter: { uid: 2, name: 'b', total: 680 },
+    biggestSc: { uid: 1, name: 'a', amount: 500, message: 'yo' },
+    topChatter: { uid: 1, name: 'a', count: 142 },
+  }
+}
+
+test('formatSummary renders all sections', () => {
+  const out = formatSummary(baseSummary(), room)
+  expect(out).toContain('#直播总结')
+  expect(out).toContain('测试')
+  expect(out).toContain('时长 3小时42分')
+  expect(out).toContain('总收入 ¥2,817.5')
+  expect(out).toContain('🎁 礼物 2 ¥1,240.5')
+  expect(out).toContain('💌 醒目留言 2 ¥980')
+  expect(out).toContain('⚓ 大航海 2 ¥597')
+  expect(out).toContain('看过 250')
+  expect(out).toContain('峰值在线 80')
+  expect(out).toContain('点赞 3,000')
+  expect(out).toContain('新增关注 2')
+  expect(out).toContain('弹幕 3')
+  expect(out).toContain('发言 2 人')
+  expect(out).toContain('最佳金主 b ¥680')
+  expect(out).toContain('最高 SC a ¥500')
+  expect(out).toContain('最活跃 a 142 条')
+})
+
+test('formatSummary omits empty sections', () => {
+  const s = baseSummary()
+  s.gifts = { count: 0, revenue: 0 }
+  s.sc = { count: 0, revenue: 0 }
+  s.guards = { count: 0, revenue: 0 }
+  s.totalRevenue = 0
+  s.topGifter = null
+  s.biggestSc = null
+  const out = formatSummary(s, room)
+  expect(out).not.toContain('总收入')
+  expect(out).not.toContain('最佳金主')
+  expect(out).not.toContain('最高 SC')
+  expect(out).toContain('#直播总结')
+  expect(out).toContain('弹幕 3')
+})
+
+test('formatSummary marks partial sessions', () => {
+  const s = baseSummary()
+  s.partial = true
+  expect(formatSummary(s, room)).toContain('⚠️ 部分数据')
+})

--- a/src/streamSummary.ts
+++ b/src/streamSummary.ts
@@ -21,7 +21,7 @@ export interface StreamSummary {
   guards: { count: number; revenue: number }
   totalRevenue: number
   topGifter: { uid: number; name: string; total: number } | null
-  biggestSc: { uid: number; name: string; amount: number; message: string } | null
+  biggestSc: { uid: number; name: string; amount: number } | null
   topChatter: { uid: number; name: string; count: number } | null
 }
 
@@ -55,7 +55,7 @@ export class SessionStats {
   private guardCount = 0
   private guardRevenue = 0
   private readonly gifters = new Map<number, { name: string; total: number }>()
-  private biggestSc: { uid: number; name: string; amount: number; message: string } | null = null
+  private biggestSc: { uid: number; name: string; amount: number } | null = null
 
   constructor(startedAt: number, partial: boolean) {
     this.startedAt = startedAt
@@ -96,12 +96,7 @@ export class SessionStats {
         this.scCount++
         this.scRevenue += event.priceNormalized
         if (!this.biggestSc || event.priceNormalized > this.biggestSc.amount) {
-          this.biggestSc = {
-            uid: event.uid,
-            name: event.username,
-            amount: event.priceNormalized,
-            message: event.message,
-          }
+          this.biggestSc = { uid: event.uid, name: event.username, amount: event.priceNormalized }
         }
         break
       case 'toast':
@@ -243,6 +238,7 @@ export class SessionManager {
           this.sessions.set(roomId, new SessionStats(event.timestampNormalized, false))
         }
         // else LIVE duplicate -> ignore (do not reset stats)
+        // (Bilibili fires live-start twice on a real start — the second is a no-op here.)
         return
       }
       case 'live-end': {

--- a/src/streamSummary.ts
+++ b/src/streamSummary.ts
@@ -21,7 +21,7 @@ export interface StreamSummary {
   guards: { count: number; revenue: number }
   totalRevenue: number
   topGifter: { uid: number; name: string; total: number } | null
-  biggestSc: { uid: number; name: string; amount: number } | null
+  biggestSc: { uid: number; name: string; amount: number; message: string } | null
   topChatter: { uid: number; name: string; count: number } | null
 }
 
@@ -55,7 +55,7 @@ export class SessionStats {
   private guardCount = 0
   private guardRevenue = 0
   private readonly gifters = new Map<number, { name: string; total: number }>()
-  private biggestSc: { uid: number; name: string; amount: number } | null = null
+  private biggestSc: { uid: number; name: string; amount: number; message: string } | null = null
 
   constructor(startedAt: number, partial: boolean) {
     this.startedAt = startedAt
@@ -96,7 +96,12 @@ export class SessionStats {
         this.scCount++
         this.scRevenue += event.priceNormalized
         if (!this.biggestSc || event.priceNormalized > this.biggestSc.amount) {
-          this.biggestSc = { uid: event.uid, name: event.username, amount: event.priceNormalized }
+          this.biggestSc = {
+            uid: event.uid,
+            name: event.username,
+            amount: event.priceNormalized,
+            message: event.message,
+          }
         }
         break
       case 'toast':
@@ -162,8 +167,19 @@ function clock(ts: number): string {
   }).format(ts)
 }
 
-/** Render a StreamSummary as a Telegram markdown message. Pure. */
-export function formatSummary(s: StreamSummary, room: RoomConfig): string {
+/**
+ * Render a StreamSummary as a Telegram markdown message. Pure.
+ *
+ * `escapeText` is applied to every viewer-supplied field (usernames, the SC
+ * message) so a hostile value cannot inject markdown or make the downstream
+ * `md()` parser throw and suppress the whole summary. Defaults to identity for
+ * tests that don't care about escaping; production passes `md.escape`.
+ */
+export function formatSummary(
+  s: StreamSummary,
+  room: RoomConfig,
+  escapeText: (text: string) => string = text => text
+): string {
   const blocks: string[] = []
 
   let header = `#直播总结 📊 ${room.slug}`
@@ -192,9 +208,13 @@ export function formatSummary(s: StreamSummary, room: RoomConfig): string {
   blocks.push(chat.join('  ·  '))
 
   const highlights: string[] = []
-  if (s.topGifter) highlights.push(`🏆 最佳金主 ${s.topGifter.name} ¥${fmtMoney(s.topGifter.total)}`)
-  if (s.biggestSc) highlights.push(`🔥 最高 SC ${s.biggestSc.name} ¥${fmtMoney(s.biggestSc.amount)}`)
-  if (s.topChatter) highlights.push(`⚡ 最活跃 ${s.topChatter.name} ${fmtNum(s.topChatter.count)} 条`)
+  if (s.topGifter) highlights.push(`🏆 最佳金主 ${escapeText(s.topGifter.name)} ¥${fmtMoney(s.topGifter.total)}`)
+  if (s.biggestSc) {
+    highlights.push(
+      `🔥 最高 SC ${escapeText(s.biggestSc.name)} ¥${fmtMoney(s.biggestSc.amount)}: ${escapeText(s.biggestSc.message)}`
+    )
+  }
+  if (s.topChatter) highlights.push(`⚡ 最活跃 ${escapeText(s.topChatter.name)} ${fmtNum(s.topChatter.count)} 条`)
   if (highlights.length > 0) blocks.push(highlights.join('\n'))
 
   return blocks.join('\n\n')

--- a/src/streamSummary.ts
+++ b/src/streamSummary.ts
@@ -1,4 +1,5 @@
 import type { LaplaceEvent } from '@laplace.live/event-types'
+
 import type { RoomConfig } from './types'
 
 import { formatDuration } from './utils'
@@ -251,7 +252,7 @@ export class SessionManager {
         if (existing) clearTimeout(existing)
         this.timers.set(
           roomId,
-          setTimeout(() => this.finalizeRoom(roomId), this.debounceMs),
+          setTimeout(() => this.finalizeRoom(roomId), this.debounceMs)
         )
         return
       }
@@ -285,7 +286,7 @@ export class SessionManager {
 
     const summary = session.finalize(endedAt)
     Promise.resolve(this.onSummary(roomId, summary)).catch(err =>
-      console.error(`[summary] onSummary failed for room ${roomId}:`, err),
+      console.error(`[summary] onSummary failed for room ${roomId}:`, err)
     )
   }
 }

--- a/src/streamSummary.ts
+++ b/src/streamSummary.ts
@@ -1,0 +1,147 @@
+import type { LaplaceEvent } from '@laplace.live/event-types'
+
+export interface StreamSummary {
+  startedAt: number
+  endedAt: number
+  durationMs: number
+  /** true when no live-start was observed (bot started mid-stream); numbers are a lower bound. */
+  partial: boolean
+  chats: number
+  uniqueChatters: number
+  watchedMax: number
+  onlinePeak: number
+  likesMax: number
+  newFollows: number
+  gifts: { count: number; revenue: number }
+  sc: { count: number; revenue: number }
+  guards: { count: number; revenue: number }
+  totalRevenue: number
+  topGifter: { uid: number; name: string; total: number } | null
+  biggestSc: { uid: number; name: string; amount: number; message: string } | null
+  topChatter: { uid: number; name: string; count: number } | null
+}
+
+/** Event types that contribute to a stream summary. */
+export const RECORDABLE_TYPES = new Set<string>([
+  'message',
+  'watched-update',
+  'online-update',
+  'likes-update',
+  'interaction',
+  'gift',
+  'superchat',
+  'toast',
+])
+
+/** In-memory accumulator for a single live session. Pure: no I/O. */
+export class SessionStats {
+  readonly startedAt: number
+  readonly partial: boolean
+
+  private chats = 0
+  private readonly chatters = new Map<number, { name: string; count: number }>()
+  private watchedMax = 0
+  private onlinePeak = 0
+  private likesMax = 0
+  private newFollows = 0
+  private giftCount = 0
+  private giftRevenue = 0
+  private scCount = 0
+  private scRevenue = 0
+  private guardCount = 0
+  private guardRevenue = 0
+  private readonly gifters = new Map<number, { name: string; total: number }>()
+  private biggestSc: { uid: number; name: string; amount: number; message: string } | null = null
+
+  constructor(startedAt: number, partial: boolean) {
+    this.startedAt = startedAt
+    this.partial = partial
+  }
+
+  record(event: LaplaceEvent): void {
+    switch (event.type) {
+      case 'message': {
+        this.chats++
+        const c = this.chatters.get(event.uid)
+        if (c) c.count++
+        else this.chatters.set(event.uid, { name: event.username, count: 1 })
+        break
+      }
+      case 'watched-update':
+        if (event.watched > this.watchedMax) this.watchedMax = event.watched
+        break
+      case 'online-update':
+        if (event.online > this.onlinePeak) this.onlinePeak = event.online
+        break
+      case 'likes-update':
+        if (event.likes > this.likesMax) this.likesMax = event.likes
+        break
+      case 'interaction':
+        if (event.action === 2 || event.action === 4) this.newFollows++
+        break
+      case 'gift':
+        if (event.coinType === 'gold') {
+          this.giftCount++
+          this.giftRevenue += event.priceNormalized
+          const g = this.gifters.get(event.uid)
+          if (g) g.total += event.priceNormalized
+          else this.gifters.set(event.uid, { name: event.username, total: event.priceNormalized })
+        }
+        break
+      case 'superchat':
+        this.scCount++
+        this.scRevenue += event.priceNormalized
+        if (!this.biggestSc || event.priceNormalized > this.biggestSc.amount) {
+          this.biggestSc = {
+            uid: event.uid,
+            name: event.username,
+            amount: event.priceNormalized,
+            message: event.message,
+          }
+        }
+        break
+      case 'toast':
+        this.guardCount++
+        this.guardRevenue += event.priceNormalized
+        break
+      default:
+        break
+    }
+  }
+
+  finalize(endedAt: number): StreamSummary {
+    let topChatter: StreamSummary['topChatter'] = null
+    for (const [uid, v] of this.chatters) {
+      if (!topChatter || v.count > topChatter.count) {
+        topChatter = { uid, name: v.name, count: v.count }
+      }
+    }
+
+    let topGifter: StreamSummary['topGifter'] = null
+    for (const [uid, v] of this.gifters) {
+      if (!topGifter || v.total > topGifter.total) {
+        topGifter = { uid, name: v.name, total: v.total }
+      }
+    }
+
+    return {
+      startedAt: this.startedAt,
+      endedAt,
+      durationMs: Math.max(0, endedAt - this.startedAt),
+      partial: this.partial,
+      chats: this.chats,
+      uniqueChatters: this.chatters.size,
+      watchedMax: this.watchedMax,
+      onlinePeak: this.onlinePeak,
+      likesMax: this.likesMax,
+      newFollows: this.newFollows,
+      gifts: { count: this.giftCount, revenue: this.giftRevenue },
+      sc: { count: this.scCount, revenue: this.scRevenue },
+      guards: { count: this.guardCount, revenue: this.guardRevenue },
+      totalRevenue: this.giftRevenue + this.scRevenue + this.guardRevenue,
+      topGifter,
+      biggestSc: this.biggestSc,
+      topChatter,
+    }
+  }
+}

--- a/src/streamSummary.ts
+++ b/src/streamSummary.ts
@@ -203,3 +203,89 @@ export function formatSummary(s: StreamSummary, room: RoomConfig): string {
 
   return blocks.join('\n\n')
 }
+
+export interface SessionManagerOptions {
+  debounceMs: number
+  onSummary: (roomId: number, summary: StreamSummary) => void | Promise<void>
+}
+
+/**
+ * Per-room lifecycle state machine for stream summaries.
+ *
+ * State is derived from two maps: a room with a session is LIVE (no timer) or
+ * ENDING (timer pending); a room with no session is IDLE. This makes the
+ * manager idempotent against Bilibili's repeated live-start/live-end events.
+ */
+export class SessionManager {
+  private readonly debounceMs: number
+  private readonly onSummary: (roomId: number, summary: StreamSummary) => void | Promise<void>
+  private readonly sessions = new Map<number, SessionStats>()
+  private readonly timers = new Map<number, ReturnType<typeof setTimeout>>()
+  private readonly pendingEndAt = new Map<number, number>()
+
+  constructor(opts: SessionManagerOptions) {
+    this.debounceMs = opts.debounceMs
+    this.onSummary = opts.onSummary
+  }
+
+  handle(roomId: number, event: LaplaceEvent): void {
+    switch (event.type) {
+      case 'live-start': {
+        const timer = this.timers.get(roomId)
+        if (timer) {
+          // ENDING -> resume: brief blip, keep counting the same session
+          clearTimeout(timer)
+          this.timers.delete(roomId)
+          this.pendingEndAt.delete(roomId)
+        } else if (!this.sessions.has(roomId)) {
+          // IDLE -> start a new session
+          this.sessions.set(roomId, new SessionStats(event.timestampNormalized, false))
+        }
+        // else LIVE duplicate -> ignore (do not reset stats)
+        return
+      }
+      case 'live-end': {
+        if (!this.sessions.has(roomId)) return // IDLE -> nothing to end
+        this.pendingEndAt.set(roomId, event.timestampNormalized)
+        const existing = this.timers.get(roomId)
+        if (existing) clearTimeout(existing)
+        this.timers.set(
+          roomId,
+          setTimeout(() => this.finalizeRoom(roomId), this.debounceMs),
+        )
+        return
+      }
+      default: {
+        if (!RECORDABLE_TYPES.has(event.type)) return
+        let session = this.sessions.get(roomId)
+        if (!session) {
+          // Bot started mid-stream: no live-start was seen -> partial session
+          session = new SessionStats(event.timestampNormalized, true)
+          this.sessions.set(roomId, session)
+        }
+        session.record(event)
+        return
+      }
+    }
+  }
+
+  /** Cancel all pending debounce timers (e.g. on shutdown). */
+  clearAllTimers(): void {
+    for (const timer of this.timers.values()) clearTimeout(timer)
+    this.timers.clear()
+  }
+
+  private finalizeRoom(roomId: number): void {
+    const session = this.sessions.get(roomId)
+    const endedAt = this.pendingEndAt.get(roomId)
+    this.timers.delete(roomId)
+    this.pendingEndAt.delete(roomId)
+    this.sessions.delete(roomId)
+    if (!session || endedAt === undefined) return
+
+    const summary = session.finalize(endedAt)
+    Promise.resolve(this.onSummary(roomId, summary)).catch(err =>
+      console.error(`[summary] onSummary failed for room ${roomId}:`, err),
+    )
+  }
+}

--- a/src/streamSummary.ts
+++ b/src/streamSummary.ts
@@ -1,4 +1,7 @@
 import type { LaplaceEvent } from '@laplace.live/event-types'
+import type { RoomConfig } from './types'
+
+import { formatDuration } from './utils'
 
 export interface StreamSummary {
   startedAt: number
@@ -144,4 +147,59 @@ export class SessionStats {
       topChatter,
     }
   }
+}
+
+function fmtMoney(n: number): string {
+  return n.toLocaleString('en-US', { maximumFractionDigits: 1 })
+}
+
+function fmtNum(n: number): string {
+  return n.toLocaleString('en-US')
+}
+
+function clock(ts: number): string {
+  return new Intl.DateTimeFormat('zh-CN', {
+    timeZone: 'Asia/Shanghai',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(ts)
+}
+
+/** Render a StreamSummary as a Telegram markdown message. Pure. */
+export function formatSummary(s: StreamSummary, room: RoomConfig): string {
+  const blocks: string[] = []
+
+  let header = `#直播总结 📊 ${room.slug}`
+  if (s.partial) header = `⚠️ 部分数据（监控中途启动）\n${header}`
+  blocks.push(header)
+
+  blocks.push(`🕐 时长 ${formatDuration(s.durationMs)}  ·  ${clock(s.startedAt)} → ${clock(s.endedAt)}`)
+
+  const money: string[] = []
+  if (s.gifts.count > 0) money.push(`   🎁 礼物 ${fmtNum(s.gifts.count)} ¥${fmtMoney(s.gifts.revenue)}`)
+  if (s.sc.count > 0) money.push(`   💌 醒目留言 ${fmtNum(s.sc.count)} ¥${fmtMoney(s.sc.revenue)}`)
+  if (s.guards.count > 0) money.push(`   ⚓ 大航海 ${fmtNum(s.guards.count)} ¥${fmtMoney(s.guards.revenue)}`)
+  if (money.length > 0) {
+    blocks.push([`💰 总收入 ¥${fmtMoney(s.totalRevenue)}`, ...money].join('\n'))
+  }
+
+  const audience: string[] = []
+  if (s.watchedMax > 0) audience.push(`👥 看过 ${fmtNum(s.watchedMax)}`)
+  if (s.onlinePeak > 0) audience.push(`🟢 峰值在线 ${fmtNum(s.onlinePeak)}`)
+  if (s.likesMax > 0) audience.push(`👍 点赞 ${fmtNum(s.likesMax)}`)
+  if (s.newFollows > 0) audience.push(`➕ 新增关注 ${fmtNum(s.newFollows)}`)
+  if (audience.length > 0) blocks.push(audience.join('  ·  '))
+
+  const chat: string[] = [`💬 弹幕 ${fmtNum(s.chats)}`]
+  if (s.uniqueChatters > 0) chat.push(`🗣️ 发言 ${fmtNum(s.uniqueChatters)} 人`)
+  blocks.push(chat.join('  ·  '))
+
+  const highlights: string[] = []
+  if (s.topGifter) highlights.push(`🏆 最佳金主 ${s.topGifter.name} ¥${fmtMoney(s.topGifter.total)}`)
+  if (s.biggestSc) highlights.push(`🔥 最高 SC ${s.biggestSc.name} ¥${fmtMoney(s.biggestSc.amount)}`)
+  if (s.topChatter) highlights.push(`⚡ 最活跃 ${s.topChatter.name} ${fmtNum(s.topChatter.count)} 条`)
+  if (highlights.length > 0) blocks.push(highlights.join('\n'))
+
+  return blocks.join('\n\n')
 }

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from 'bun:test'
+
+import { formatDuration } from './utils'
+
+test('formatDuration: hours and minutes', () => {
+  expect(formatDuration((3 * 60 + 42) * 60_000)).toBe('3小时42分')
+})
+
+test('formatDuration: minutes only', () => {
+  expect(formatDuration(42 * 60_000)).toBe('42分')
+})
+
+test('formatDuration: whole hours', () => {
+  expect(formatDuration(3 * 3_600_000)).toBe('3小时')
+})
+
+test('formatDuration: zero', () => {
+  expect(formatDuration(0)).toBe('0分')
+})

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,3 +29,14 @@ export function timeFromNow(time: number, { locale = 'zh-CN' }: RelativeTimeProp
 
   return relativeTimeFormat.format(Math.round(value), unit)
 }
+
+/** Format a duration in milliseconds as a short zh-CN string, e.g. "3小时42分". */
+export function formatDuration(ms: number): string {
+  const totalMinutes = Math.floor(ms / 60_000)
+  const hours = Math.floor(totalMinutes / 60)
+  const minutes = totalMinutes % 60
+
+  if (hours > 0 && minutes > 0) return `${hours}小时${minutes}分`
+  if (hours > 0) return `${hours}小时`
+  return `${minutes}分`
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,5 +26,6 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noPropertyAccessFromIndexSignature": false
-  }
+  },
+  "exclude": ["node_modules", "references"]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-of-stream summary notifications for monitored live rooms, posting duration, revenue breakdowns, audience metrics, and top activity highlights.
  * Debounces rapid start/end “flapping” to avoid duplicate summaries, with support for partial sessions when needed.

* **Documentation**
  * Expanded the Stream Summary documentation, including what is posted and a multi-bridge caveat about possible duplicates/inflation.

* **Tests**
  * Added comprehensive automated tests for summary formatting and session lifecycle behavior.

* **Chores**
  * Updated dependencies and development tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->