### PR TITLE
Enhance stream summary persistence and session management features

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,77 +35,20 @@ test("hello world", () => {
 });
 ```
 
-## Frontend
+## Code Conventions
 
-Use HTML imports with `Bun.serve()`. Don't use `vite`. HTML imports fully support React, CSS, Tailwind.
+### TypeScript
 
-Server:
+- Path alias: `@/*` maps to `./src/*`
+- No `as` type assertions or `biome ignore` workarounds - fix underlying issues
 
-```ts#index.ts
-import index from "./index.html"
+### Comments
 
-Bun.serve({
-  routes: {
-    "/": index,
-    "/api/users/:id": {
-      GET: (req) => {
-        return new Response(JSON.stringify({ id: req.params.id }));
-      },
-    },
-  },
-  // optional websocket support
-  websocket: {
-    open: (ws) => {
-      ws.send("Hello, world!");
-    },
-    message: (ws, message) => {
-      ws.send(message);
-    },
-    close: (ws) => {
-      // handle close
-    }
-  },
-  development: {
-    hmr: true,
-    console: true,
-  }
-})
-```
+Comments must be **sparse and terse** — verbosity is the problem; a long comment is worse than no comment. One exception: **JSDoc/TSDoc doc-comments** (`/** … */`) attached to a declaration surface in editor hover and autocomplete — keep them, but keep them tight.
 
-HTML files can import .tsx, .jsx or .js files directly and Bun's bundler will transpile & bundle automatically. `<link>` tags can point to stylesheets and Bun's CSS bundler will bundle.
-
-```html#index.html
-<html>
-  <body>
-    <h1>Hello, world!</h1>
-    <script type="module" src="./frontend.tsx"></script>
-  </body>
-</html>
-```
-
-With the following `frontend.tsx`:
-
-```tsx#frontend.tsx
-import React from "react";
-
-// import .css files directly and it works
-import './index.css';
-
-import { createRoot } from "react-dom/client";
-
-const root = createRoot(document.body);
-
-export default function Frontend() {
-  return <h1>Hello, world!</h1>;
-}
-
-root.render(<Frontend />);
-```
-
-Then, run index.ts
-
-```sh
-bun --hot ./index.ts
-```
-
-For more information, read the Bun API docs in `node_modules/bun-types/docs/**.md`.
+- **Keep doc-comments on declarations.** A `/** … */` block on a function, method, class, type, interface, or exported const earns its place by showing in hover tooltips and IntelliSense — don't delete it just because it echoes the name (e.g. keep `/** Read the active global prompt. */` over `getActiveGlobalPrompt()`). Hold it to one line where you can; reach for `@param`/`@returns`/`@example` only to add what the signature can't say (units, ranges, edge cases, ownership). Never pad it into a paragraph.
+- **Cut name-restaters elsewhere.** Delete any `//` inline note or block comment on local variables and implementation details that merely restates a name, signature, type, or an obvious operation.
+- **Condense long block comments to 1–2 lines.** Compress multi-paragraph module headers, design-rationale essays, and per-item writeups down to their single essential point (usually a non-obvious _why_). Drop history, tangents, and cross-references to unrelated modules.
+- **Keep only genuinely non-obvious information, in 1–2 lines** — a subtle edge case, a non-obvious _why_, a workaround, an invariant, units/ranges, or a gotcha. Never a paragraph.
+- **Prefer self-documenting names.** For local/internal logic, skip the comment unless it's genuinely non-obvious or you're asked to add one; a good name beats a comment.
+- **Never remove or alter** functional/tooling directives (`@ts-expect-error`, `@ts-ignore`, `/// <reference>`, `biome-ignore`, `eslint-disable`, `prettier-ignore`, `@vite-ignore`), `TODO`/`FIXME`/`HACK` notes, or license headers. When cleaning comments, change only comments — never code.

--- a/README.md
+++ b/README.md
@@ -59,16 +59,24 @@ When a monitored stream ends, the bot posts a single summary to the room's
 chats, 大航海), and per-user highlights (top gifter, biggest super chat, most
 active chatter).
 
-Metrics are accumulated **in memory** — there is no database, and an in-progress
-stream's totals are lost if the process restarts. Bilibili fires
-`live-start`/`live-end` repeatedly and flaps on brief drops, so the summary is
-sent after a debounce window (`STREAM_SUMMARY_DEBOUNCE_MS`, default 45s) once the
-stream has truly ended.
+Metrics are accumulated in memory and snapshotted to `bot-data/summary-state.json`
+(atomic temp-file + rename; every 10s while state changes, before each summary is
+sent, and on shutdown), so in-progress streams survive restarts, upgrades, and
+crashes. A hard crash loses at most ~10s of stats; events that arrive while the
+bot is down are not counted. If a stream ends entirely during downtime, a
+best-effort summary (marked ⚠️) is still sent after startup once the room stays
+silent for the revalidation window (`STREAM_SUMMARY_REVALIDATE_MS`, default
+5 min). Bilibili fires `live-start`/`live-end` repeatedly and flaps on brief
+drops, so the summary is sent after a debounce window
+(`STREAM_SUMMARY_DEBOUNCE_MS`, default 45s) once the stream has truly ended.
 
 > **Multi-bridge note:** counts assume each room is pinned to a single `bridge`.
 > If a room is monitored by multiple bridges, duplicate events will inflate the
 > summary — pin the room to one bridge (as you already do to avoid duplicate
 > notifications).
+
+> **Docker note:** mount `bot-data/` as a volume (it already holds the Telegram
+> session) or summary state will not survive container replacement.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -61,14 +61,14 @@ active chatter).
 
 Metrics are accumulated in memory and snapshotted to `bot-data/summary-state.json`
 (atomic temp-file + rename; every 10s while state changes, before each summary is
-sent, and on shutdown), so in-progress streams survive restarts, upgrades, and
-crashes. A hard crash loses at most ~10s of stats; events that arrive while the
-bot is down are not counted. If a stream ends entirely during downtime, a
-best-effort summary (marked ⚠️) is still sent after startup once the room stays
-silent for the revalidation window (`STREAM_SUMMARY_REVALIDATE_MS`, default
-5 min). Bilibili fires `live-start`/`live-end` repeatedly and flaps on brief
-drops, so the summary is sent after a debounce window
-(`STREAM_SUMMARY_DEBOUNCE_MS`, default 45s) once the stream has truly ended.
+sent, and on shutdown), so an in-progress stream survives restarts and upgrades as
+long as it is still live when the bot comes back — a hard crash loses at most ~10s
+of stats, and events that arrive while the bot is down are not counted. If the
+stream ends entirely while the bot is down, its summary is not sent: the stale
+session is silently replaced when the next stream starts. Bilibili fires
+`live-start`/`live-end` repeatedly and flaps on brief drops, so the summary is
+sent after a debounce window (`STREAM_SUMMARY_DEBOUNCE_MS`, default 45s) once the
+stream has truly ended.
 
 > **Multi-bridge note:** counts assume each room is pinned to a single `bridge`.
 > If a room is monitored by multiple bridges, duplicate events will inflate the

--- a/docs/superpowers/plans/2026-07-02-stream-summary-persistence.md
+++ b/docs/superpowers/plans/2026-07-02-stream-summary-persistence.md
@@ -20,6 +20,8 @@
 - Exact constants: `STREAM_SUMMARY_FLUSH_MS = 10_000`, `STREAM_SUMMARY_REVALIDATE_MS = 300_000`; state file `bot-data/summary-state.json`; temp file is `<path>.tmp`; snapshot `version: 1`.
 - Exact marker text: `⚠️ 未观测到下播（服务中断），结束时间为最后活动时间`.
 - Every task must leave `bun test` green and `bunx tsc --noEmit` clean.
+- No `as` type assertions (CLAUDE.md). At JSON boundaries use a typed variable declaration (`const x: T = JSON.parse(...)`) plus the runtime validation the task specifies. (The pre-existing `as unknown as LaplaceEvent` in the test `ev()` helper stays.)
+- Comments sparse and terse (CLAUDE.md): inline `//` comments 1–2 lines carrying only non-obvious *why*; doc-comments (`/** */`) on declarations kept, held tight.
 
 ## File Structure
 
@@ -270,7 +272,7 @@ test('SessionStats snapshot/restore round-trips through JSON', () => {
   stats.record(ev('toast', { uid: 3, username: 'c', priceNormalized: 198 }))
 
   // Round-trip through actual JSON to prove the snapshot is JSON-safe
-  const snap = JSON.parse(JSON.stringify(stats.snapshot())) as SessionStatsSnapshot
+  const snap: SessionStatsSnapshot = JSON.parse(JSON.stringify(stats.snapshot()))
   const restored = SessionStats.restore(snap)
 
   expect(restored.lastEventAt).toBe(stats.lastEventAt)
@@ -478,7 +480,7 @@ test('SessionManager: a restored ENDING room emits after the debounce', async ()
   a.manager.handle(100, ev('live-start', { timestampNormalized: 1_000 }))
   a.manager.handle(100, ev('message', { uid: 1, username: 'a', timestampNormalized: 1_100 }))
   a.manager.handle(100, ev('live-end', { timestampNormalized: 2_000 }))
-  const snap = JSON.parse(JSON.stringify(a.manager.snapshot())) as ManagerSnapshot
+  const snap: ManagerSnapshot = JSON.parse(JSON.stringify(a.manager.snapshot()))
   a.manager.clearAllTimers() // simulate shutdown before the debounce fired
 
   const b = makeManager()
@@ -655,8 +657,7 @@ Add `snapshot`, `restore`, and `finalizeStale` after `clearAllTimers`:
 
   /**
    * Rehydrate sessions from a snapshot (startup only). ENDING rooms re-arm the
-   * debounce for the full window; LIVE rooms get one revalidation window to
-   * prove the stream is still running, else a best-effort summary is emitted.
+   * debounce; LIVE rooms get one revalidation window before a best-effort summary.
    */
   restore(snap: ManagerSnapshot): void {
     for (const [roomId, room] of snap.rooms) {
@@ -833,7 +834,7 @@ export async function loadSummarySnapshot(path: string): Promise<ManagerSnapshot
   const file = Bun.file(path)
   if (!(await file.exists())) return null
   try {
-    const data = (await file.json()) as ManagerSnapshot
+    const data: ManagerSnapshot = await file.json()
     if (data?.version !== 1 || !Array.isArray(data.rooms)) {
       console.warn(`[summary] Discarding snapshot with unsupported shape/version: ${path}`)
       return null
@@ -940,10 +941,8 @@ const summaryManager = new SessionManager({
   },
 })
 
-// Persist manager state so in-progress streams survive restarts. Compares the
-// rooms payload (savedAt alone must not count as a change) and skips unchanged
-// writes. Save failures are logged and never crash the flush loop — the
-// previous on-disk snapshot stays intact thanks to the atomic rename.
+// Persist in-progress sessions across restarts. Dirty-check compares rooms only
+// (savedAt always changes); a failed save logs — the old snapshot stays intact.
 let lastPersistedRooms: string | null = null
 async function flushSummaryState(): Promise<void> {
   const snap = summaryManager.snapshot()

--- a/docs/superpowers/plans/2026-07-02-stream-summary-persistence.md
+++ b/docs/superpowers/plans/2026-07-02-stream-summary-persistence.md
@@ -1,5 +1,11 @@
 # Stream Summary Persistence Implementation Plan
 
+> **Superseded in part (2026-07-02):** the missed-end revalidation subsystem this
+> plan builds (revalidateMs, finalizeStale, endEstimated, lastEventAt — Tasks 1,
+> 2, and parts of 4/6) was descoped after implementation. See the Amendment in
+> `docs/superpowers/specs/2026-07-02-stream-summary-persistence-design.md`.
+> Retained unmodified below as the historical execution record.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** In-progress stream-summary state survives process restarts (upgrades, container replacement, crashes) via an atomically-written JSON snapshot, and a stream that ends while the bot is down still gets a best-effort summary.

--- a/docs/superpowers/plans/2026-07-02-stream-summary-persistence.md
+++ b/docs/superpowers/plans/2026-07-02-stream-summary-persistence.md
@@ -1,0 +1,1046 @@
+# Stream Summary Persistence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** In-progress stream-summary state survives process restarts (upgrades, container replacement, crashes) via an atomically-written JSON snapshot, and a stream that ends while the bot is down still gets a best-effort summary.
+
+**Architecture:** `SessionStats`/`SessionManager` (in `src/streamSummary.ts`) gain pure `snapshot()`/`restore()` serialization; a new I/O-only module `src/summaryPersistence.ts` reads/writes the snapshot file atomically; `src/index.ts` wires flush points (10s interval, before each summary send, on SIGINT/SIGTERM) and restores at startup. Restored LIVE rooms get a revalidation timer — silence means the stream ended during downtime, emitting a summary flagged `endEstimated`.
+
+**Tech Stack:** Bun (runtime, `bun test`, `Bun.file`/`Bun.write`), `node:fs/promises` `rename` (atomic replace; no Bun equivalent), Biome formatting.
+
+**Spec:** `docs/superpowers/specs/2026-07-02-stream-summary-persistence-design.md`
+
+## Global Constraints
+
+- Bun toolchain only: `bun test`, `Bun.file`/`Bun.write`; the only `node:` API allowed is `rename`/`unlink` from `node:fs/promises`.
+- No new dependencies. `types.ts` and `config.yaml` unchanged — no new configuration.
+- Formatting (biome.jsonc): single quotes, semicolons `asNeeded` (write none), 2-space indent, trailing commas `es5`, line width 120, `arrowParentheses: asNeeded`.
+- Conventional commits matching repo history (`feat:`, `test:`, `docs:`).
+- Snapshot types must be JSON-safe: no `Map`, no `undefined`, no `Date` in serialized form; `Map`s serialize as entry arrays.
+- Exact constants: `STREAM_SUMMARY_FLUSH_MS = 10_000`, `STREAM_SUMMARY_REVALIDATE_MS = 300_000`; state file `bot-data/summary-state.json`; temp file is `<path>.tmp`; snapshot `version: 1`.
+- Exact marker text: `⚠️ 未观测到下播（服务中断），结束时间为最后活动时间`.
+- Every task must leave `bun test` green and `bunx tsc --noEmit` clean.
+
+## File Structure
+
+- `src/streamSummary.ts` (modify) — snapshot types, `lastEventAt`, `endEstimated`, `SessionStats.snapshot/restore`, `SessionManager.snapshot/restore` + revalidation.
+- `src/streamSummary.test.ts` (modify) — new tests per task.
+- `src/summaryPersistence.ts` (create) — `loadSummarySnapshot`/`saveSummarySnapshot`, atomic rename.
+- `src/summaryPersistence.test.ts` (create) — persistence tests.
+- `src/consts.ts` (modify) — `STREAM_SUMMARY_REVALIDATE_MS` (Task 4), `STREAM_SUMMARY_FLUSH_MS` (Task 6).
+- `src/index.ts` (modify, Task 6 only) — restore at startup, flush interval, save-before-send, SIGTERM.
+- `README.md` (modify, Task 6) — persistence + Docker volume note.
+
+---
+
+### Task 1: `SessionStats.lastEventAt`
+
+**Files:**
+- Modify: `src/streamSummary.ts` (SessionStats class, ~lines 51–150)
+- Test: `src/streamSummary.test.ts`
+
+**Interfaces:**
+- Consumes: existing `SessionStats` (constructor `(startedAt: number, partial: boolean)`, `record(event)`).
+- Produces: `get lastEventAt(): number` — most recent recorded event's `timestampNormalized`, never below `startedAt`; private backing field is named `lastActivity`. Task 3 serializes it; Task 4 uses it as the best-effort end time.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/streamSummary.test.ts`, after the `'SessionStats with no activity yields empty summary'` test:
+
+```ts
+test('SessionStats tracks the latest event timestamp as lastEventAt', () => {
+  const stats = new SessionStats(1_000, false)
+  expect(stats.lastEventAt).toBe(1_000) // starts at startedAt
+
+  stats.record(ev('message', { uid: 1, username: 'a', timestampNormalized: 5_000 }))
+  expect(stats.lastEventAt).toBe(5_000)
+
+  // an out-of-order older event must not move it backwards
+  stats.record(ev('online-update', { online: 10, timestampNormalized: 4_000 }))
+  expect(stats.lastEventAt).toBe(5_000)
+
+  stats.record(ev('likes-update', { likes: 3, timestampNormalized: 6_500 }))
+  expect(stats.lastEventAt).toBe(6_500)
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/streamSummary.test.ts -t 'lastEventAt'`
+Expected: FAIL (`lastEventAt` is `undefined`, `expect(received).toBe(1000)` fails)
+
+- [ ] **Step 3: Implement**
+
+In `src/streamSummary.ts`, inside `SessionStats`:
+
+Add a field after the `liveStartBound` declaration:
+
+```ts
+  /** Timestamp of the most recent recorded event (never below startedAt). */
+  private lastActivity: number
+```
+
+At the end of the constructor body:
+
+```ts
+    this.lastActivity = startedAt
+```
+
+Add a getter after the `hasLiveStart` getter:
+
+```ts
+  /** Most recent recorded event's timestamp (startedAt when nothing has been recorded yet). */
+  get lastEventAt(): number {
+    return this.lastActivity
+  }
+```
+
+Add as the first line of `record(event)`, before the `switch`:
+
+```ts
+    if (event.timestampNormalized > this.lastActivity) this.lastActivity = event.timestampNormalized
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test src/streamSummary.test.ts && bunx tsc --noEmit`
+Expected: all tests PASS, tsc clean
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/streamSummary.ts src/streamSummary.test.ts
+git commit -m "feat: track last event timestamp in SessionStats"
+```
+
+---
+
+### Task 2: `endEstimated` flag and its summary marker
+
+**Files:**
+- Modify: `src/streamSummary.ts` (`StreamSummary` interface ~line 7, `finalize` ~line 152, `formatSummary` header block ~line 226)
+- Test: `src/streamSummary.test.ts` (new tests + `baseSummary()` fixture)
+
+**Interfaces:**
+- Consumes: `StreamSummary`, `SessionStats.finalize`, `formatSummary`.
+- Produces: `StreamSummary.endEstimated: boolean`; `finalize(endedAt: number, endEstimated = false): StreamSummary`. Existing callers stay valid (default `false`). Task 4's `finalizeStale` calls `finalize(session.lastEventAt, true)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `src/streamSummary.test.ts` after the Task 1 test:
+
+```ts
+test('finalize marks endEstimated only when requested', () => {
+  const stats = new SessionStats(1_000, false)
+  expect(stats.finalize(2_000).endEstimated).toBe(false)
+  expect(stats.finalize(2_000, true).endEstimated).toBe(true)
+})
+```
+
+And after the `'formatSummary marks partial sessions'` test:
+
+```ts
+test('formatSummary renders the endEstimated marker', () => {
+  const s = baseSummary()
+  s.endEstimated = true
+  expect(formatSummary(s, room)).toContain('⚠️ 未观测到下播（服务中断），结束时间为最后活动时间')
+})
+
+test('formatSummary renders both partial and endEstimated markers together', () => {
+  const s = baseSummary()
+  s.partial = true
+  s.endEstimated = true
+  const out = formatSummary(s, room)
+  expect(out).toContain('⚠️ 部分数据（监控中途启动）')
+  expect(out).toContain('⚠️ 未观测到下播（服务中断），结束时间为最后活动时间')
+})
+```
+
+Also update the `baseSummary()` fixture: add `endEstimated: false,` on the line after `partial: false,`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test src/streamSummary.test.ts -t 'endEstimated'`
+Expected: FAIL (`endEstimated` is `undefined`; marker not found)
+
+- [ ] **Step 3: Implement**
+
+In `src/streamSummary.ts`:
+
+In the `StreamSummary` interface, after the `partial` member:
+
+```ts
+  /** true when no live-end was observed (stream ended while the bot was down); endedAt is the last event seen — a lower bound. */
+  endEstimated: boolean
+```
+
+Change the `finalize` signature and returned object:
+
+```ts
+  finalize(endedAt: number, endEstimated = false): StreamSummary {
+```
+
+and in the returned object literal, after `partial: this.partial,`:
+
+```ts
+      endEstimated,
+```
+
+In `formatSummary`, the header block becomes:
+
+```ts
+  let header = `#${room.slug} #直播总结`
+  if (s.partial) header = `⚠️ 部分数据（监控中途启动）\n${header}`
+  if (s.endEstimated) header = `⚠️ 未观测到下播（服务中断），结束时间为最后活动时间\n${header}`
+  blocks.push(header)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test src/streamSummary.test.ts && bunx tsc --noEmit`
+Expected: all tests PASS, tsc clean
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/streamSummary.ts src/streamSummary.test.ts
+git commit -m "feat: add endEstimated flag for streams that end during downtime"
+```
+
+---
+
+### Task 3: `SessionStats.snapshot()` / `SessionStats.restore()`
+
+**Files:**
+- Modify: `src/streamSummary.ts`
+- Test: `src/streamSummary.test.ts`
+
+**Interfaces:**
+- Consumes: `SessionStats` fields (all private counters, `lastActivity` from Task 1).
+- Produces (used by Task 4 and Task 5):
+
+```ts
+/** JSON-safe serialized form of SessionStats (Maps as entry arrays). */
+export interface SessionStatsSnapshot {
+  startedAt: number
+  partial: boolean
+  liveStartBound: boolean
+  lastEventAt: number
+  chats: number
+  chatters: Array<[number, { name: string; count: number }]>
+  watchedMax: number
+  onlinePeak: number
+  onlineSum: number
+  onlineSamples: number
+  likesMax: number
+  newFollows: number
+  giftCount: number
+  giftRevenue: number
+  scCount: number
+  scRevenue: number
+  guardCount: number
+  guardRevenue: number
+  spenders: Array<[number, { name: string; total: number }]>
+}
+```
+
+plus `snapshot(): SessionStatsSnapshot` and `static restore(snap: SessionStatsSnapshot): SessionStats`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `src/streamSummary.test.ts` (extend the type-only import at the bottom section or add near the other `./streamSummary` imports):
+
+```ts
+import type { SessionStatsSnapshot } from './streamSummary'
+```
+
+```ts
+test('SessionStats snapshot/restore round-trips through JSON', () => {
+  const stats = new SessionStats(1_000, false)
+  stats.record(ev('message', { uid: 1, username: 'a', timestampNormalized: 1_100 }))
+  stats.record(ev('message', { uid: 1, username: 'a', timestampNormalized: 1_200 }))
+  stats.record(ev('message', { uid: 2, username: 'b', timestampNormalized: 1_300 }))
+  stats.record(ev('watched-update', { watched: 250 }))
+  stats.record(ev('online-update', { online: 50 }))
+  stats.record(ev('online-update', { online: 80 }))
+  stats.record(ev('likes-update', { likes: 3_000 }))
+  stats.record(ev('interaction', { action: 2 }))
+  stats.record(ev('gift', { uid: 2, username: 'b', coinType: 'gold', priceNormalized: 30 }))
+  stats.record(ev('superchat', { uid: 3, username: 'c', priceNormalized: 50, message: 'hi' }))
+  stats.record(ev('toast', { uid: 3, username: 'c', priceNormalized: 198 }))
+
+  // Round-trip through actual JSON to prove the snapshot is JSON-safe
+  const snap = JSON.parse(JSON.stringify(stats.snapshot())) as SessionStatsSnapshot
+  const restored = SessionStats.restore(snap)
+
+  expect(restored.lastEventAt).toBe(stats.lastEventAt)
+  expect(restored.hasLiveStart).toBe(true)
+  expect(restored.finalize(9_000)).toEqual(stats.finalize(9_000))
+})
+
+test('SessionStats restore preserves partial/anchor state and keeps accumulating', () => {
+  const stats = new SessionStats(5_000, true) // partial, not yet anchored
+  stats.record(ev('message', { uid: 1, username: 'a', timestampNormalized: 5_100 }))
+
+  const restored = SessionStats.restore(stats.snapshot())
+  expect(restored.partial).toBe(true)
+  expect(restored.hasLiveStart).toBe(false)
+
+  restored.record(ev('message', { uid: 2, username: 'b', timestampNormalized: 5_200 }))
+  const s = restored.finalize(6_000)
+  expect(s.chats).toBe(2)
+  expect(s.uniqueChatters).toBe(2)
+  expect(s.partial).toBe(true)
+})
+
+test('SessionStats restore preserves a promoted (anchored) partial session', () => {
+  const stats = new SessionStats(5_000, true)
+  stats.bindLiveStart() // promoted by a real live-start
+  const restored = SessionStats.restore(stats.snapshot())
+  expect(restored.partial).toBe(true)
+  expect(restored.hasLiveStart).toBe(true)
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test src/streamSummary.test.ts -t 'snapshot'`
+Expected: FAIL (`stats.snapshot is not a function`)
+
+- [ ] **Step 3: Implement**
+
+In `src/streamSummary.ts`, add the `SessionStatsSnapshot` interface (from the Interfaces block above, verbatim) directly above the `SessionStats` class.
+
+Add the two methods at the end of the `SessionStats` class body (after `finalize`):
+
+```ts
+  /** Serialize every accumulator field into a JSON-safe object. */
+  snapshot(): SessionStatsSnapshot {
+    const chatters: Array<[number, { name: string; count: number }]> = []
+    for (const [uid, v] of this.chatters) chatters.push([uid, { ...v }])
+    const spenders: Array<[number, { name: string; total: number }]> = []
+    for (const [uid, v] of this.spenders) spenders.push([uid, { ...v }])
+    return {
+      startedAt: this.startedAt,
+      partial: this.partial,
+      liveStartBound: this.liveStartBound,
+      lastEventAt: this.lastActivity,
+      chats: this.chats,
+      chatters,
+      watchedMax: this.watchedMax,
+      onlinePeak: this.onlinePeak,
+      onlineSum: this.onlineSum,
+      onlineSamples: this.onlineSamples,
+      likesMax: this.likesMax,
+      newFollows: this.newFollows,
+      giftCount: this.giftCount,
+      giftRevenue: this.giftRevenue,
+      scCount: this.scCount,
+      scRevenue: this.scRevenue,
+      guardCount: this.guardCount,
+      guardRevenue: this.guardRevenue,
+      spenders,
+    }
+  }
+
+  /** Exact inverse of snapshot(): restore(x.snapshot()).finalize(t) deep-equals x.finalize(t). */
+  static restore(snap: SessionStatsSnapshot): SessionStats {
+    const s = new SessionStats(snap.startedAt, snap.partial)
+    s.liveStartBound = snap.liveStartBound
+    s.lastActivity = snap.lastEventAt
+    s.chats = snap.chats
+    for (const [uid, v] of snap.chatters) s.chatters.set(uid, { ...v })
+    s.watchedMax = snap.watchedMax
+    s.onlinePeak = snap.onlinePeak
+    s.onlineSum = snap.onlineSum
+    s.onlineSamples = snap.onlineSamples
+    s.likesMax = snap.likesMax
+    s.newFollows = snap.newFollows
+    s.giftCount = snap.giftCount
+    s.giftRevenue = snap.giftRevenue
+    s.scCount = snap.scCount
+    s.scRevenue = snap.scRevenue
+    s.guardCount = snap.guardCount
+    s.guardRevenue = snap.guardRevenue
+    for (const [uid, v] of snap.spenders) s.spenders.set(uid, { ...v })
+    return s
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test src/streamSummary.test.ts && bunx tsc --noEmit`
+Expected: all tests PASS, tsc clean
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/streamSummary.ts src/streamSummary.test.ts
+git commit -m "feat: add SessionStats snapshot/restore serialization"
+```
+
+---
+
+### Task 4: `SessionManager` snapshot/restore + post-restore revalidation
+
+**Files:**
+- Modify: `src/consts.ts` (after `STREAM_SUMMARY_DEBOUNCE_MS`)
+- Modify: `src/streamSummary.ts` (`SessionManagerOptions`, `SessionManager`)
+- Test: `src/streamSummary.test.ts` (update `makeManager`, add tests)
+
+**Interfaces:**
+- Consumes: `SessionStatsSnapshot`, `SessionStats.restore`, `SessionStats.snapshot`, `session.lastEventAt` (Task 1/3), `finalize(endedAt, endEstimated)` (Task 2).
+- Produces (used by Tasks 5–6):
+
+```ts
+/** One room's persisted state: its session plus the pending end (ENDING state) if any. */
+export interface RoomSnapshot {
+  pendingEndAt: number | null
+  session: SessionStatsSnapshot
+}
+
+/** JSON-safe serialized form of SessionManager (timers are re-derived on restore). */
+export interface ManagerSnapshot {
+  version: 1
+  savedAt: number
+  rooms: Array<[number, RoomSnapshot]>
+}
+```
+
+- `SessionManagerOptions` gains `revalidateMs?: number` (defaults to `STREAM_SUMMARY_REVALIDATE_MS`).
+- `SessionManager.snapshot(): ManagerSnapshot`, `SessionManager.restore(snap: ManagerSnapshot): void`.
+- `src/consts.ts` gains `STREAM_SUMMARY_REVALIDATE_MS = 300_000`.
+
+- [ ] **Step 1: Add the constant**
+
+In `src/consts.ts`, after `STREAM_SUMMARY_DEBOUNCE_MS`:
+
+```ts
+/**
+ * After restoring a LIVE room from a persisted snapshot, how long to wait for
+ * any event before declaring the stream ended during downtime and emitting a
+ * best-effort summary. Generous headroom over Bilibili's periodic
+ * online/watched heartbeats plus bridge reconnect time.
+ */
+export const STREAM_SUMMARY_REVALIDATE_MS = 300_000
+```
+
+- [ ] **Step 2: Update `makeManager` and write the failing tests**
+
+In `src/streamSummary.test.ts`, extend the type import added in Task 3:
+
+```ts
+import type { ManagerSnapshot, SessionStatsSnapshot } from './streamSummary'
+```
+
+Replace the existing `makeManager` with (adds a required-for-tests small revalidation window):
+
+```ts
+function makeManager() {
+  const calls: Array<{ roomId: number; summary: StreamSummary }> = []
+  const manager = new SessionManager({
+    debounceMs: 30,
+    revalidateMs: 30,
+    onSummary: (roomId, summary) => {
+      calls.push({ roomId, summary })
+    },
+  })
+  return { calls, manager }
+}
+```
+
+Add these tests at the end of the file:
+
+```ts
+test('SessionManager: snapshot captures LIVE and ENDING rooms', () => {
+  const { manager } = makeManager()
+  manager.handle(100, ev('live-start', { timestampNormalized: 1_000 }))
+  manager.handle(100, ev('message', { uid: 1, username: 'a', timestampNormalized: 1_100 }))
+  manager.handle(200, ev('live-start', { timestampNormalized: 2_000 }))
+  manager.handle(200, ev('live-end', { timestampNormalized: 3_000 }))
+
+  const snap = manager.snapshot()
+  manager.clearAllTimers()
+
+  expect(snap.version).toBe(1)
+  expect(typeof snap.savedAt).toBe('number')
+  expect(snap.rooms.length).toBe(2)
+  const room100 = snap.rooms.find(([id]) => id === 100)?.[1]
+  const room200 = snap.rooms.find(([id]) => id === 200)?.[1]
+  expect(room100?.pendingEndAt).toBeNull()
+  expect(room100?.session.chats).toBe(1)
+  expect(room100?.session.lastEventAt).toBe(1_100)
+  expect(room200?.pendingEndAt).toBe(3_000)
+})
+
+test('SessionManager: a restored ENDING room emits after the debounce', async () => {
+  const a = makeManager()
+  a.manager.handle(100, ev('live-start', { timestampNormalized: 1_000 }))
+  a.manager.handle(100, ev('message', { uid: 1, username: 'a', timestampNormalized: 1_100 }))
+  a.manager.handle(100, ev('live-end', { timestampNormalized: 2_000 }))
+  const snap = JSON.parse(JSON.stringify(a.manager.snapshot())) as ManagerSnapshot
+  a.manager.clearAllTimers() // simulate shutdown before the debounce fired
+
+  const b = makeManager()
+  b.manager.restore(snap)
+  await Bun.sleep(60)
+
+  expect(b.calls.length).toBe(1)
+  expect(b.calls[0]?.summary.endedAt).toBe(2_000) // the observed live-end, not wall clock
+  expect(b.calls[0]?.summary.endEstimated).toBe(false)
+  expect(b.calls[0]?.summary.chats).toBe(1)
+})
+
+test('SessionManager: a restored ENDING room can still flap-resume', async () => {
+  const a = makeManager()
+  a.manager.handle(100, ev('live-start', { timestampNormalized: 1_000 }))
+  a.manager.handle(100, ev('live-end', { timestampNormalized: 2_000 }))
+  const snap = a.manager.snapshot()
+  a.manager.clearAllTimers()
+
+  const b = makeManager()
+  b.manager.restore(snap)
+  b.manager.handle(100, ev('live-start', { timestampNormalized: 2_010 })) // resume cancels the re-armed debounce
+  await Bun.sleep(60)
+  expect(b.calls.length).toBe(0)
+
+  b.manager.handle(100, ev('live-end', { timestampNormalized: 3_000 }))
+  await Bun.sleep(60)
+  expect(b.calls.length).toBe(1)
+  expect(b.calls[0]?.summary.startedAt).toBe(1_000)
+  expect(b.calls[0]?.summary.endedAt).toBe(3_000)
+})
+
+test('SessionManager: a restored LIVE room with no activity emits a best-effort summary', async () => {
+  const a = makeManager()
+  a.manager.handle(100, ev('live-start', { timestampNormalized: 1_000 }))
+  a.manager.handle(100, ev('message', { uid: 1, username: 'a', timestampNormalized: 1_500 }))
+  const snap = a.manager.snapshot()
+  a.manager.clearAllTimers()
+
+  const b = makeManager()
+  b.manager.restore(snap)
+  await Bun.sleep(60) // past revalidateMs with no events
+
+  expect(b.calls.length).toBe(1)
+  expect(b.calls[0]?.summary.endEstimated).toBe(true)
+  expect(b.calls[0]?.summary.endedAt).toBe(1_500) // lastEventAt, not wall clock
+  expect(b.calls[0]?.summary.chats).toBe(1)
+})
+
+test('SessionManager: any event cancels revalidation and the stream continues', async () => {
+  const a = makeManager()
+  a.manager.handle(100, ev('live-start', { timestampNormalized: 1_000 }))
+  a.manager.handle(100, ev('message', { uid: 1, username: 'a', timestampNormalized: 1_500 }))
+  const snap = a.manager.snapshot()
+  a.manager.clearAllTimers()
+
+  const b = makeManager()
+  b.manager.restore(snap)
+  b.manager.handle(100, ev('message', { uid: 2, username: 'b', timestampNormalized: 5_000 }))
+  await Bun.sleep(60) // past revalidateMs — must NOT fire, the room proved it is live
+  expect(b.calls.length).toBe(0)
+
+  b.manager.handle(100, ev('live-end', { timestampNormalized: 6_000 }))
+  await Bun.sleep(60)
+  expect(b.calls.length).toBe(1)
+  expect(b.calls[0]?.summary.endEstimated).toBe(false)
+  expect(b.calls[0]?.summary.chats).toBe(2) // pre-restart + post-restart merged
+  expect(b.calls[0]?.summary.startedAt).toBe(1_000)
+})
+
+test('SessionManager: clearAllTimers cancels revalidation timers too', async () => {
+  const a = makeManager()
+  a.manager.handle(100, ev('live-start', { timestampNormalized: 1_000 }))
+  const snap = a.manager.snapshot()
+  a.manager.clearAllTimers()
+
+  const b = makeManager()
+  b.manager.restore(snap)
+  b.manager.clearAllTimers()
+  await Bun.sleep(60)
+  expect(b.calls.length).toBe(0)
+})
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `bun test src/streamSummary.test.ts`
+Expected: FAIL — TypeScript/`ManagerSnapshot` unresolved and `manager.snapshot is not a function`; pre-existing tests still pass
+
+- [ ] **Step 4: Implement**
+
+In `src/streamSummary.ts`:
+
+Add to the imports:
+
+```ts
+import { STREAM_SUMMARY_REVALIDATE_MS } from './consts'
+```
+
+Add the two interfaces (verbatim from the Interfaces block above) right after the `SessionStatsSnapshot` interface: `RoomSnapshot`, `ManagerSnapshot`.
+
+In `SessionManagerOptions`, after `debounceMs: number`:
+
+```ts
+  /**
+   * Silence window after restoring a LIVE room before declaring the stream
+   * ended during downtime (defaults to STREAM_SUMMARY_REVALIDATE_MS).
+   */
+  revalidateMs?: number
+```
+
+In `SessionManager`, add fields after `pendingEndAt`:
+
+```ts
+  private readonly revalidateMs: number
+  private readonly revalidateTimers = new Map<number, ReturnType<typeof setTimeout>>()
+```
+
+In the constructor, after `this.debounceMs = opts.debounceMs`:
+
+```ts
+    this.revalidateMs = opts.revalidateMs ?? STREAM_SUMMARY_REVALIDATE_MS
+```
+
+Add a private helper after the constructor:
+
+```ts
+  /** Cancel a pending post-restore revalidation: the room has shown signs of life. */
+  private cancelRevalidation(roomId: number): void {
+    const timer = this.revalidateTimers.get(roomId)
+    if (timer) {
+      clearTimeout(timer)
+      this.revalidateTimers.delete(roomId)
+    }
+  }
+```
+
+In `handle()`, add `this.cancelRevalidation(roomId)` as the **first statement** of the `'live-start'` case and of the `'live-end'` case, and in the `default` case **after** the `RECORDABLE_TYPES` guard:
+
+```ts
+      default: {
+        if (!RECORDABLE_TYPES.has(event.type)) return
+        this.cancelRevalidation(roomId)
+        let session = this.sessions.get(roomId)
+        // ... rest unchanged
+```
+
+Replace `clearAllTimers` with:
+
+```ts
+  /** Cancel all pending timers (e.g. on shutdown). */
+  clearAllTimers(): void {
+    for (const timer of this.timers.values()) clearTimeout(timer)
+    this.timers.clear()
+    for (const timer of this.revalidateTimers.values()) clearTimeout(timer)
+    this.revalidateTimers.clear()
+  }
+```
+
+Add `snapshot`, `restore`, and `finalizeStale` after `clearAllTimers`:
+
+```ts
+  /** Serialize all rooms' in-progress state (JSON-safe; timers are re-derived on restore). */
+  snapshot(): ManagerSnapshot {
+    const rooms: Array<[number, RoomSnapshot]> = []
+    for (const [roomId, session] of this.sessions) {
+      rooms.push([
+        roomId,
+        { pendingEndAt: this.pendingEndAt.get(roomId) ?? null, session: session.snapshot() },
+      ])
+    }
+    return { version: 1, savedAt: Date.now(), rooms }
+  }
+
+  /**
+   * Rehydrate sessions from a snapshot (startup only). ENDING rooms re-arm the
+   * debounce for the full window; LIVE rooms get one revalidation window to
+   * prove the stream is still running, else a best-effort summary is emitted.
+   */
+  restore(snap: ManagerSnapshot): void {
+    for (const [roomId, room] of snap.rooms) {
+      this.sessions.set(roomId, SessionStats.restore(room.session))
+      if (room.pendingEndAt !== null) {
+        this.pendingEndAt.set(roomId, room.pendingEndAt)
+        this.timers.set(
+          roomId,
+          setTimeout(() => this.finalizeRoom(roomId), this.debounceMs)
+        )
+      } else {
+        this.revalidateTimers.set(
+          roomId,
+          setTimeout(() => this.finalizeStale(roomId), this.revalidateMs)
+        )
+      }
+    }
+  }
+
+  /**
+   * Post-restore revalidation expired with no activity: the stream ended while
+   * the bot was down. Emit a best-effort summary bounded by the last event seen.
+   */
+  private finalizeStale(roomId: number): void {
+    this.revalidateTimers.delete(roomId)
+    const session = this.sessions.get(roomId)
+    this.sessions.delete(roomId)
+    if (!session) return
+
+    const summary = session.finalize(session.lastEventAt, true)
+    Promise.resolve(this.onSummary(roomId, summary)).catch(err =>
+      console.error(`[summary] onSummary failed for room ${roomId}:`, err)
+    )
+  }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `bun test && bunx tsc --noEmit`
+Expected: all tests PASS (including all pre-existing ones), tsc clean
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/consts.ts src/streamSummary.ts src/streamSummary.test.ts
+git commit -m "feat: add SessionManager snapshot/restore with post-restore revalidation"
+```
+
+---
+
+### Task 5: `summaryPersistence` module (atomic file I/O)
+
+**Files:**
+- Create: `src/summaryPersistence.ts`
+- Create: `src/summaryPersistence.test.ts`
+
+**Interfaces:**
+- Consumes: `ManagerSnapshot` (Task 4).
+- Produces (used by Task 6):
+  - `loadSummarySnapshot(path: string): Promise<ManagerSnapshot | null>` — `null` on missing file (silent), corrupt JSON, or version ≠ 1 (warn); never throws.
+  - `saveSummarySnapshot(path: string, snap: ManagerSnapshot): Promise<void>` — writes `<path>.tmp` then atomically renames over `<path>`; throws on I/O failure (callers handle).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/summaryPersistence.test.ts`:
+
+```ts
+import { unlink } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, expect, test } from 'bun:test'
+
+import type { ManagerSnapshot } from './streamSummary'
+
+import { loadSummarySnapshot, saveSummarySnapshot } from './summaryPersistence'
+
+const path = join(tmpdir(), `laplace-jupiter-summary-state-${process.pid}.json`)
+
+afterEach(async () => {
+  await unlink(path).catch(() => {})
+  await unlink(`${path}.tmp`).catch(() => {})
+})
+
+function fixture(): ManagerSnapshot {
+  return {
+    version: 1,
+    savedAt: 1_751_400_000_000,
+    rooms: [
+      [
+        100,
+        {
+          pendingEndAt: null,
+          session: {
+            startedAt: 1_000,
+            partial: false,
+            liveStartBound: true,
+            lastEventAt: 1_500,
+            chats: 1,
+            chatters: [[1, { name: 'a', count: 1 }]],
+            watchedMax: 250,
+            onlinePeak: 80,
+            onlineSum: 130,
+            onlineSamples: 2,
+            likesMax: 3_000,
+            newFollows: 2,
+            giftCount: 2,
+            giftRevenue: 40,
+            scCount: 2,
+            scRevenue: 150,
+            guardCount: 2,
+            guardRevenue: 396,
+            spenders: [[3, { name: 'c', total: 248 }]],
+          },
+        },
+      ],
+    ],
+  }
+}
+
+test('save/load round-trips a snapshot', async () => {
+  await saveSummarySnapshot(path, fixture())
+  expect(await loadSummarySnapshot(path)).toEqual(fixture())
+})
+
+test('load returns null for a missing file', async () => {
+  expect(await loadSummarySnapshot(path)).toBeNull()
+})
+
+test('load returns null for corrupt JSON', async () => {
+  await Bun.write(path, '{not json')
+  expect(await loadSummarySnapshot(path)).toBeNull()
+})
+
+test('load returns null for an unsupported version', async () => {
+  await Bun.write(path, JSON.stringify({ version: 99, savedAt: 0, rooms: [] }))
+  expect(await loadSummarySnapshot(path)).toBeNull()
+})
+
+test('save leaves no tmp file behind', async () => {
+  await saveSummarySnapshot(path, fixture())
+  expect(await Bun.file(`${path}.tmp`).exists()).toBe(false)
+})
+
+test('save overwrites a previous snapshot atomically', async () => {
+  await saveSummarySnapshot(path, fixture())
+  const next = fixture()
+  next.savedAt = 1_751_400_010_000
+  next.rooms = []
+  await saveSummarySnapshot(path, next)
+  expect(await loadSummarySnapshot(path)).toEqual(next)
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test src/summaryPersistence.test.ts`
+Expected: FAIL (`Cannot find module './summaryPersistence'`)
+
+- [ ] **Step 3: Implement**
+
+Create `src/summaryPersistence.ts`:
+
+```ts
+import { rename } from 'node:fs/promises'
+
+import type { ManagerSnapshot } from './streamSummary'
+
+/**
+ * Read a previously saved summary snapshot. Returns null (never throws) when
+ * the file is missing, unparseable, or has an unsupported version — the bot
+ * then simply starts with empty state.
+ */
+export async function loadSummarySnapshot(path: string): Promise<ManagerSnapshot | null> {
+  const file = Bun.file(path)
+  if (!(await file.exists())) return null
+  try {
+    const data = (await file.json()) as ManagerSnapshot
+    if (data?.version !== 1 || !Array.isArray(data.rooms)) {
+      console.warn(`[summary] Discarding snapshot with unsupported shape/version: ${path}`)
+      return null
+    }
+    return data
+  } catch (err) {
+    console.warn(`[summary] Discarding unreadable snapshot ${path}:`, err)
+    return null
+  }
+}
+
+/**
+ * Atomically persist a snapshot: write <path>.tmp, then rename over <path>.
+ * A crash mid-write leaves the previous snapshot intact (POSIX rename).
+ * Throws on I/O failure — callers log and carry on.
+ */
+export async function saveSummarySnapshot(path: string, snap: ManagerSnapshot): Promise<void> {
+  const tmp = `${path}.tmp`
+  await Bun.write(tmp, JSON.stringify(snap))
+  await rename(tmp, path)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test && bunx tsc --noEmit`
+Expected: all tests PASS, tsc clean
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/summaryPersistence.ts src/summaryPersistence.test.ts
+git commit -m "feat: add atomic summary state persistence"
+```
+
+---
+
+### Task 6: Wire persistence into the app + README
+
+**Files:**
+- Modify: `src/consts.ts`
+- Modify: `src/index.ts`
+- Modify: `README.md:62-66` (the "in memory" paragraph) and `README.md:71` (after the multi-bridge note)
+
+**Interfaces:**
+- Consumes: `loadSummarySnapshot`/`saveSummarySnapshot` (Task 5), `summaryManager.snapshot()`/`.restore()` (Task 4).
+- Produces: running app behavior; no new exports.
+
+There are no unit tests for this task (it is I/O wiring); verification is typecheck + full suite + lint + a startup smoke check.
+
+- [ ] **Step 1: Add the flush constant**
+
+In `src/consts.ts`, after `STREAM_SUMMARY_REVALIDATE_MS`:
+
+```ts
+/** Persist stream-summary state at most this often (the write is skipped when nothing changed). */
+export const STREAM_SUMMARY_FLUSH_MS = 10_000
+```
+
+- [ ] **Step 2: Wire `src/index.ts`**
+
+2a. Extend the consts import and add the persistence import (final import block):
+
+```ts
+import {
+  EMOJI_MAP,
+  GUARD_TYPE_DICT,
+  PRICE_TIER_EMOJI,
+  STREAM_SUMMARY_DEBOUNCE_MS,
+  STREAM_SUMMARY_FLUSH_MS,
+  SUPERCHAT_TIER_EMOJI,
+} from './consts'
+import { EventStore, formatMessagesContext } from './eventStore'
+import { formatSummary, SessionManager } from './streamSummary'
+import { loadSummarySnapshot, saveSummarySnapshot } from './summaryPersistence'
+import { timeFromNow } from './utils'
+```
+
+2b. After the `const botDataDir = 'bot-data'` line:
+
+```ts
+const summaryStatePath = `${botDataDir}/summary-state.json`
+```
+
+2c. Replace the `summaryManager` construction so the state is persisted **before** the send (at-most-once delivery):
+
+```ts
+// Stream summary: accumulate per-room metrics and emit a summary after each stream
+const summaryManager = new SessionManager({
+  debounceMs: STREAM_SUMMARY_DEBOUNCE_MS,
+  onSummary: async (roomId, summary) => {
+    const room = roomMap.get(roomId)
+    if (!room) return
+    // Persist first: the finalized room is already gone from the snapshot, so
+    // a crash after the send cannot re-emit this summary on the next restore.
+    await flushSummaryState()
+    const message = formatSummary(summary, room, md.escape)
+    try {
+      await tg.sendText(room.telegram_announce_ch, md(message), { disableWebPreview: true })
+      console.log(`[summary] Sent stream summary for ${room.slug} (${roomId})`)
+    } catch (err) {
+      console.error(`[summary] Failed to send summary for ${room.slug} (${roomId}):`, err)
+    }
+  },
+})
+
+// Persist manager state so in-progress streams survive restarts. Compares the
+// rooms payload (savedAt alone must not count as a change) and skips unchanged
+// writes. Save failures are logged and never crash the flush loop — the
+// previous on-disk snapshot stays intact thanks to the atomic rename.
+let lastPersistedRooms: string | null = null
+async function flushSummaryState(): Promise<void> {
+  const snap = summaryManager.snapshot()
+  const roomsJson = JSON.stringify(snap.rooms)
+  if (roomsJson === lastPersistedRooms) return
+  try {
+    await saveSummarySnapshot(summaryStatePath, snap)
+    lastPersistedRooms = roomsJson
+  } catch (err) {
+    console.error('[summary] Failed to persist summary state:', err)
+  }
+}
+```
+
+Note: `revalidateMs` is deliberately not passed — the manager defaults to `STREAM_SUMMARY_REVALIDATE_MS`.
+
+2d. In `start()`, right after the `console.log('Logged in as', user.username)` line (restore before bridges connect so no events race the rehydration):
+
+```ts
+    // Restore in-progress stream sessions persisted by a previous run
+    const restored = await loadSummarySnapshot(summaryStatePath)
+    if (restored) {
+      summaryManager.restore(restored)
+      console.log(`[summary] Restored ${restored.rooms.length} in-progress session(s)`)
+    }
+    setInterval(() => {
+      void flushSummaryState()
+    }, STREAM_SUMMARY_FLUSH_MS)
+```
+
+2e. Replace the whole `process.on('SIGINT', ...)` block (including its `// Graceful shutdown` comment) with:
+
+```ts
+// Graceful shutdown (SIGINT from a terminal, SIGTERM from Docker)
+async function shutdown() {
+  console.log('\nShutting down...')
+
+  // Persist in-progress sessions, then cancel pending timers — restore()
+  // re-arms them on the next startup
+  await flushSummaryState()
+  summaryManager.clearAllTimers()
+
+  // Disconnect all event bridges
+  for (const { name, client } of clients) {
+    console.log(`Disconnecting from ${name}...`)
+    client.disconnect()
+  }
+
+  await tg.disconnect()
+  process.exit(0)
+}
+
+process.on('SIGINT', shutdown)
+process.on('SIGTERM', shutdown)
+```
+
+- [ ] **Step 3: Update `README.md`**
+
+Replace the paragraph at lines 62–66 ("Metrics are accumulated **in memory** — … truly ended.") with:
+
+```markdown
+Metrics are accumulated in memory and snapshotted to `bot-data/summary-state.json`
+(atomic temp-file + rename; every 10s while state changes, before each summary is
+sent, and on shutdown), so in-progress streams survive restarts, upgrades, and
+crashes. A hard crash loses at most ~10s of stats; events that arrive while the
+bot is down are not counted. If a stream ends entirely during downtime, a
+best-effort summary (marked ⚠️) is still sent after startup once the room stays
+silent for the revalidation window (`STREAM_SUMMARY_REVALIDATE_MS`, default
+5 min). Bilibili fires `live-start`/`live-end` repeatedly and flaps on brief
+drops, so the summary is sent after a debounce window
+(`STREAM_SUMMARY_DEBOUNCE_MS`, default 45s) once the stream has truly ended.
+```
+
+Then, directly after the existing multi-bridge blockquote (line 71), add:
+
+```markdown
+> **Docker note:** mount `bot-data/` as a volume (it already holds the Telegram
+> session) or summary state will not survive container replacement.
+```
+
+- [ ] **Step 4: Verify**
+
+Run: `bunx tsc --noEmit && bun test && bun run lint`
+Expected: tsc clean (this typechecks all of the `index.ts` wiring); all tests PASS; biome reports no errors (if it flags formatting, run `bun run format` and re-check)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/consts.ts src/index.ts README.md
+git commit -m "feat: persist stream summary state across restarts"
+```
+
+---
+
+## Verification checklist (end of plan)
+
+- `bun test` — full suite green (existing + ~15 new tests).
+- `bunx tsc --noEmit` — clean.
+- `bun run lint` — clean.
+- Manual (optional, needs real tokens): start the bot, let a room accumulate a few events, `kill -TERM` the process, confirm `bot-data/summary-state.json` exists, restart, and look for `[summary] Restored N in-progress session(s)` in the log.

--- a/docs/superpowers/specs/2026-07-02-stream-summary-persistence-design.md
+++ b/docs/superpowers/specs/2026-07-02-stream-summary-persistence-design.md
@@ -1,10 +1,33 @@
 # Stream Summary Persistence — Design
 
 **Date:** 2026-07-02
-**Status:** Approved
+**Status:** Approved (amended — see Amendment below)
 **Component:** `laplace-jupiter`
 **Supersedes:** the "No database, no persistence" decision in
 `2026-06-20-stream-summary-design.md`
+
+## Amendment (2026-07-02): missed-end revalidation descoped
+
+After implementation, the revalidation subsystem (5-min post-restore silence
+timer, `finalizeStale`, `endEstimated` flag/marker, `lastEventAt` tracking) was
+judged not worth its complexity and removed. This reverses the earlier "never
+lose a summary" choice:
+
+- **New accepted limitation:** a stream that ends entirely while the bot is
+  down produces **no summary**. Its restored session is kept but **unanchored**
+  (`liveStartBound` cleared on restore of LIVE rooms), so the next stream's
+  `live-start` *supersedes* it — stale data is silently dropped instead of
+  merging two streams into one corrupted summary.
+- Still-live streams across a restart, and rooms restored in the ENDING state
+  (debounce re-armed), behave exactly as originally specified.
+- A Redis-backed store was considered as an alternative simplification and
+  rejected: the storage backend is the thinnest layer (~50 lines); the
+  complexity lives in serialization + restore semantics, which any backend
+  needs. Optional Redis would also drop persistence for no-Redis deployments
+  and add an external dependency, while `bot-data/` is already volume-mounted.
+
+Sections below describing revalidation, `endEstimated`, and `lastEventAt` are
+retained for history but no longer current.
 
 ## Goal
 

--- a/docs/superpowers/specs/2026-07-02-stream-summary-persistence-design.md
+++ b/docs/superpowers/specs/2026-07-02-stream-summary-persistence-design.md
@@ -1,0 +1,226 @@
+# Stream Summary Persistence — Design
+
+**Date:** 2026-07-02
+**Status:** Approved
+**Component:** `laplace-jupiter`
+**Supersedes:** the "No database, no persistence" decision in
+`2026-06-20-stream-summary-design.md`
+
+## Goal
+
+In-progress stream-summary state must survive process restarts (service
+upgrades, container replacement, crashes). Today the state lives only in RAM
+inside `SessionManager`; any restart silently discards the whole in-progress
+stream and no summary is ever sent for it.
+
+Accepted tolerances (user decisions):
+
+- **Crash-safe, cheap:** periodic snapshot; a hard crash may lose up to one
+  flush interval (~10s) of stats.
+- **Events during downtime are lost** — restored numbers are a lower bound.
+- **Never lose a summary:** if the stream ended while the bot was down, still
+  send a best-effort summary on startup, clearly labeled, rather than dropping
+  it.
+- **At-most-once delivery:** on a crash at the exact moment of sending, prefer
+  losing that summary over sending it twice.
+
+## Approach (chosen: full-state JSON snapshot)
+
+Serialize the entire `SessionManager` state to a single JSON file in
+`bot-data/` on a throttled cadence and at shutdown; rehydrate it on startup.
+Rejected alternatives: `bun:sqlite` incremental tables (schema + upsert
+machinery for a few KB of state) and append-only event log + replay (unbounded
+growth, and contradicts the accepted event-loss tolerance).
+
+## State & serialization (pure, in `src/streamSummary.ts`)
+
+### `SessionStats` changes
+
+- New tracked field **`lastEventAt`** — initialized to `startedAt`, bumped to
+  `max(lastEventAt, event.timestampNormalized)` in `record()`. This is the
+  best-effort end time for a stream that ends during downtime.
+- **`snapshot(): SessionStatsSnapshot`** — plain-JSON object of every
+  accumulator field (`startedAt`, `partial`, `liveStartBound`, `lastEventAt`,
+  counters, maxes, sums, revenue fields), with the two `Map`s (`chatters`,
+  `spenders`) serialized as entry arrays.
+- **`static restore(snap: SessionStatsSnapshot): SessionStats`** — exact
+  inverse. Round-trip invariant: `restore(snapshot()).finalize(t)` deep-equals
+  `finalize(t)`.
+
+### `SessionManager` changes
+
+- **`snapshot(): ManagerSnapshot`** — all rooms' session snapshots plus
+  `pendingEndAt` where set. Timers are never serialized; they are re-derived
+  on restore.
+- **`restore(snap: ManagerSnapshot): void`** — rehydrates sessions and re-arms
+  timers (see Restore behavior). Called once at startup before bridges
+  connect.
+- New option **`revalidateMs`** (default `STREAM_SUMMARY_REVALIDATE_MS`,
+  injectable for tests, like `debounceMs`).
+
+### Snapshot file shape
+
+```json
+{
+  "version": 1,
+  "savedAt": 1751400000000,
+  "rooms": [
+    [100, {
+      "pendingEndAt": null,
+      "session": {
+        "startedAt": 1751390000000,
+        "partial": false,
+        "liveStartBound": true,
+        "lastEventAt": 1751399990000,
+        "chats": 42,
+        "chatters": [[1, { "name": "a", "count": 40 }], [2, { "name": "b", "count": 2 }]],
+        "watchedMax": 250, "onlinePeak": 80, "onlineSum": 130, "onlineSamples": 2,
+        "likesMax": 3000, "newFollows": 2,
+        "giftCount": 2, "giftRevenue": 40,
+        "scCount": 2, "scRevenue": 150,
+        "guardCount": 2, "guardRevenue": 396,
+        "spenders": [[3, { "name": "c", "total": 248 }]]
+      }
+    }]
+  ]
+}
+```
+
+`version` mismatch or unparseable content → log a warning, discard, start
+fresh. `savedAt` is informational (logging/debugging only; no staleness cap —
+see Edge cases).
+
+## Persistence module (new `src/summaryPersistence.ts`)
+
+Small I/O-only module so `streamSummary.ts` stays pure:
+
+- **`load(): Promise<ManagerSnapshot | null>`** — read
+  `bot-data/summary-state.json`; on missing file return `null` silently; on
+  corrupt/unversioned content log a warning and return `null`.
+- **`save(snap: ManagerSnapshot): Promise<void>`** — write
+  `bot-data/summary-state.tmp` then atomically `rename()` over
+  `bot-data/summary-state.json` (POSIX rename; no torn file on crash). Uses
+  `Bun.file`/`Bun.write` for I/O and `node:fs/promises` `rename` (no Bun
+  equivalent).
+
+`bot-data/` already exists at startup, is gitignored, and already holds
+persistent state (the mtcute session), so it is the natural volume-mounted
+home.
+
+## Flush points (wired in `src/index.ts`)
+
+1. **Periodic:** every `STREAM_SUMMARY_FLUSH_MS = 10_000` ms, serialize the
+   manager; skip the write when the JSON is unchanged from the last save (the
+   state is a few KB, so stringify-and-compare is negligible).
+2. **On summary emit:** inside `onSummary`, **save before `tg.sendText`**. By
+   this point `finalizeRoom` has already deleted the session, so the saved
+   snapshot no longer contains the room — a crash after the send cannot
+   re-emit it on restore (at-most-once). A crash between this save and the
+   send loses that summary; accepted.
+3. **On shutdown:** add a **SIGTERM** handler (Docker sends SIGTERM; today
+   only SIGINT is handled). Both handlers: `await save` → `clearAllTimers` →
+   disconnect bridges → disconnect Telegram → exit.
+
+A failed `save()` (disk full, permissions) is logged and never crashes the
+process or the flush loop; the previous on-disk snapshot remains intact
+thanks to the atomic rename.
+
+## Restore behavior (startup)
+
+Startup order: ensure `bot-data/` → `tg.start()` → `load()` + `restore()` →
+connect bridges. Restoring before bridges connect means no events race the
+rehydration; restoring after `tg.start()` means a summary emitted later can
+actually be delivered.
+
+Per restored room:
+
+- **Was ENDING** (`pendingEndAt` set): re-arm the 45s debounce timer for the
+  full `debounceMs`. The summary then emits normally, and a flap-resume
+  arriving in time still cancels it — the state machine is unchanged.
+- **Was LIVE** (no `pendingEndAt`): restore the session and arm a
+  **revalidation timer** of `STREAM_SUMMARY_REVALIDATE_MS = 300_000` (5 min —
+  generous headroom over Bilibili's periodic online/watched heartbeats plus
+  bridge reconnect time).
+  - Any handled event for that room (recordable, `live-start`, or `live-end`)
+    cancels the revalidation timer: the stream is genuinely still live, keep
+    counting toward one normal summary. A `live-end` simply starts the normal
+    ENDING debounce.
+  - If it fires with no activity, the stream ended during downtime: finalize
+    with `endedAt = lastEventAt`, set `endEstimated = true`, and emit through
+    the normal `onSummary` path.
+
+## Message change
+
+`StreamSummary` gains **`endEstimated: boolean`** (default `false`): true when
+no `live-end` was observed and `endedAt` is the last event seen (a lower
+bound). `formatSummary` renders it as its own warning line in the header
+block, independent of the existing `partial` marker, e.g.:
+
+```
+⚠️ 未观测到下播（服务中断），结束时间为最后活动时间
+```
+
+(wording tweakable at implementation time). A session can carry both markers
+(joined mid-stream *and* ended during downtime).
+
+A restored session that continues normally produces a normal, unlabeled
+summary — the events lost during downtime are silently accepted per the
+stated tolerance.
+
+## Edge cases & limitations
+
+- **Very old snapshot** (bot down for days): the best-effort summary is still
+  sent — "never lose a summary" — and its own start/end timestamps make the
+  lateness self-explanatory. No age cap, no extra config.
+- **Stream A ends during downtime and stream B starts before revalidation
+  resolves** (either during the downtime itself or within the 5-min window
+  after restart): B's events cancel A's revalidation timer and merge into A's
+  restored session, yielding one combined summary. A gap-based tiebreak was
+  considered and rejected: downtime itself creates large event gaps, so it
+  cannot distinguish "new stream" from "quiet restart" without false splits.
+  Accepted as a rare limitation of the cheap approach.
+- **Crash between periodic flushes:** loses up to ~10s of stats; accepted.
+- **Crash between the pre-send save and the Telegram send:** that summary is
+  lost (at-most-once); accepted.
+- **Docker:** persistence requires `bot-data/` to be a mounted volume (it
+  already must be for the Telegram session to survive container
+  replacement). Document in README.
+
+## Files touched
+
+- `src/streamSummary.ts` — `lastEventAt`; `SessionStats.snapshot/restore`;
+  `SessionManager.snapshot/restore` + revalidation timers; `endEstimated` in
+  `StreamSummary` + `formatSummary` marker; snapshot types.
+- **new** `src/summaryPersistence.ts` — `load`/`save` with atomic rename.
+- `src/consts.ts` — `STREAM_SUMMARY_FLUSH_MS = 10_000`,
+  `STREAM_SUMMARY_REVALIDATE_MS = 300_000`.
+- `src/index.ts` — load+restore at startup; periodic flush interval;
+  save-before-send in `onSummary`; SIGTERM handler; save on shutdown.
+- `README.md` — persistence note + volume-mount caveat.
+- `types.ts` / `config.yaml` — **unchanged** (no new configuration).
+
+## Testing
+
+`bun test` against the pure units, same style as the existing suite (real
+timers with tiny injected windows, spy `onSummary`):
+
+- **`SessionStats`:** snapshot→restore→finalize deep-equals the original
+  finalize (fully populated and empty sessions); `lastEventAt` tracks the max
+  event timestamp.
+- **`SessionManager`:**
+  - snapshot mid-stream → restore into a fresh manager → continue events →
+    one summary with combined totals;
+  - restore with `pendingEndAt` → summary emits after `debounceMs` (and a
+    flap-resume before expiry still cancels it);
+  - restore LIVE + event arrives → revalidation canceled, normal summary at
+    the real end, `endEstimated === false`;
+  - restore LIVE + silence → summary after `revalidateMs` with
+    `endEstimated === true` and `endedAt === lastEventAt`.
+- **`formatSummary`:** renders the `endEstimated` marker; renders both
+  markers when combined with `partial`.
+- **`summaryPersistence`:** save/load round-trip; missing file → `null`;
+  corrupt JSON / wrong version → `null` with warning; tmp file is not left
+  behind after a successful save.
+
+The `onSummary` save-before-send ordering lives in `index.ts` wiring and is
+verified by review/manual test rather than unit test.

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -98,3 +98,11 @@ export function SUPERCHAT_TIER_EMOJI(price: number): string {
  * collapses those bursts into a single logical stream and a single summary.
  */
 export const STREAM_SUMMARY_DEBOUNCE_MS = 45_000
+
+/**
+ * After restoring a LIVE room from a persisted snapshot, how long to wait for
+ * any event before declaring the stream ended during downtime and emitting a
+ * best-effort summary. Generous headroom over Bilibili's periodic
+ * online/watched heartbeats plus bridge reconnect time.
+ */
+export const STREAM_SUMMARY_REVALIDATE_MS = 300_000

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -99,13 +99,5 @@ export function SUPERCHAT_TIER_EMOJI(price: number): string {
  */
 export const STREAM_SUMMARY_DEBOUNCE_MS = 45_000
 
-/**
- * After restoring a LIVE room from a persisted snapshot, how long to wait for
- * any event before declaring the stream ended during downtime and emitting a
- * best-effort summary. Generous headroom over Bilibili's periodic
- * online/watched heartbeats plus bridge reconnect time.
- */
-export const STREAM_SUMMARY_REVALIDATE_MS = 300_000
-
 /** Persist stream-summary state at most this often (the write is skipped when nothing changed). */
 export const STREAM_SUMMARY_FLUSH_MS = 10_000

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -106,3 +106,6 @@ export const STREAM_SUMMARY_DEBOUNCE_MS = 45_000
  * online/watched heartbeats plus bridge reconnect time.
  */
 export const STREAM_SUMMARY_REVALIDATE_MS = 300_000
+
+/** Persist stream-summary state at most this often (the write is skipped when nothing changed). */
+export const STREAM_SUMMARY_FLUSH_MS = 10_000

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,10 +12,12 @@ import {
   GUARD_TYPE_DICT,
   PRICE_TIER_EMOJI,
   STREAM_SUMMARY_DEBOUNCE_MS,
+  STREAM_SUMMARY_FLUSH_MS,
   SUPERCHAT_TIER_EMOJI,
 } from './consts'
 import { EventStore, formatMessagesContext } from './eventStore'
 import { formatSummary, SessionManager } from './streamSummary'
+import { loadSummarySnapshot, saveSummarySnapshot } from './summaryPersistence'
 import { timeFromNow } from './utils'
 
 // Load configuration
@@ -31,6 +33,7 @@ console.log(`Loaded configuration for ${config.rooms.length} rooms and ${config.
 
 // Ensure bot-data directory exists
 const botDataDir = 'bot-data'
+const summaryStatePath = `${botDataDir}/summary-state.json`
 const { stat, mkdir } = await import('node:fs/promises')
 
 try {
@@ -60,6 +63,9 @@ const summaryManager = new SessionManager({
   onSummary: async (roomId, summary) => {
     const room = roomMap.get(roomId)
     if (!room) return
+    // Persist first: the finalized room is already gone from the snapshot, so
+    // a crash after the send cannot re-emit this summary on the next restore.
+    await flushSummaryState()
     const message = formatSummary(summary, room, md.escape)
     try {
       await tg.sendText(room.telegram_announce_ch, md(message), { disableWebPreview: true })
@@ -69,6 +75,21 @@ const summaryManager = new SessionManager({
     }
   },
 })
+
+// Persist in-progress sessions across restarts. Dirty-check compares rooms only
+// (savedAt always changes); a failed save logs — the old snapshot stays intact.
+let lastPersistedRooms: string | null = null
+async function flushSummaryState(): Promise<void> {
+  const snap = summaryManager.snapshot()
+  const roomsJson = JSON.stringify(snap.rooms)
+  if (roomsJson === lastPersistedRooms) return
+  try {
+    await saveSummarySnapshot(summaryStatePath, snap)
+    lastPersistedRooms = roomsJson
+  } catch (err) {
+    console.error('[summary] Failed to persist summary state:', err)
+  }
+}
 
 // Create event bridge clients
 const clients: { name: string; client: LaplaceEventBridgeClient }[] = []
@@ -368,6 +389,16 @@ async function start() {
     const user = await tg.start({ botToken: process.env.TELEGRAM_BOT_TOKEN })
     console.log('Logged in as', user.username)
 
+    // Restore in-progress stream sessions persisted by a previous run
+    const restored = await loadSummarySnapshot(summaryStatePath)
+    if (restored) {
+      summaryManager.restore(restored)
+      console.log(`[summary] Restored ${restored.rooms.length} in-progress session(s)`)
+    }
+    setInterval(() => {
+      void flushSummaryState()
+    }, STREAM_SUMMARY_FLUSH_MS)
+
     // Connect to all LAPLACE Event Bridges
     console.log('Connecting to event bridges...')
     const promises = clients.map(async ({ name, client }) => {
@@ -395,11 +426,13 @@ async function start() {
   }
 }
 
-// Graceful shutdown
-process.on('SIGINT', async () => {
+// Graceful shutdown (SIGINT from a terminal, SIGTERM from Docker)
+async function shutdown() {
   console.log('\nShutting down...')
 
-  // Cancel any pending summary timers (in-memory data is discarded on shutdown)
+  // Persist in-progress sessions, then cancel pending timers — restore()
+  // re-arms them on the next startup
+  await flushSummaryState()
   summaryManager.clearAllTimers()
 
   // Disconnect all event bridges
@@ -410,7 +443,10 @@ process.on('SIGINT', async () => {
 
   await tg.disconnect()
   process.exit(0)
-})
+}
+
+process.on('SIGINT', shutdown)
+process.on('SIGTERM', shutdown)
 
 // Start the bot
 start()

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,10 +83,10 @@ let flushChain: Promise<void> = Promise.resolve()
 /** Flushes are chained: concurrent callers (interval, onSummary, shutdown) queue instead of colliding on the tmp file. */
 function flushSummaryState(): Promise<void> {
   flushChain = flushChain.then(async () => {
-    const snap = summaryManager.snapshot()
-    const roomsJson = JSON.stringify(snap.rooms)
-    if (roomsJson === lastPersistedRooms) return
     try {
+      const snap = summaryManager.snapshot()
+      const roomsJson = JSON.stringify(snap.rooms)
+      if (roomsJson === lastPersistedRooms) return
       await saveSummarySnapshot(summaryStatePath, snap)
       lastPersistedRooms = roomsJson
     } catch (err) {
@@ -397,8 +397,12 @@ async function start() {
     // Restore in-progress stream sessions persisted by a previous run
     const restored = await loadSummarySnapshot(summaryStatePath)
     if (restored) {
-      summaryManager.restore(restored)
-      console.log(`[summary] Restored ${restored.rooms.length} in-progress session(s)`)
+      try {
+        summaryManager.restore(restored)
+        console.log(`[summary] Restored ${restored.rooms.length} in-progress session(s)`)
+      } catch (err) {
+        console.error('[summary] Failed to restore summary state, starting fresh:', err)
+      }
     }
     setInterval(() => {
       void flushSummaryState()

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,16 +79,21 @@ const summaryManager = new SessionManager({
 // Persist in-progress sessions across restarts. Dirty-check compares rooms only
 // (savedAt always changes); a failed save logs — the old snapshot stays intact.
 let lastPersistedRooms: string | null = null
-async function flushSummaryState(): Promise<void> {
-  const snap = summaryManager.snapshot()
-  const roomsJson = JSON.stringify(snap.rooms)
-  if (roomsJson === lastPersistedRooms) return
-  try {
-    await saveSummarySnapshot(summaryStatePath, snap)
-    lastPersistedRooms = roomsJson
-  } catch (err) {
-    console.error('[summary] Failed to persist summary state:', err)
-  }
+let flushChain: Promise<void> = Promise.resolve()
+/** Flushes are chained: concurrent callers (interval, onSummary, shutdown) queue instead of colliding on the tmp file. */
+function flushSummaryState(): Promise<void> {
+  flushChain = flushChain.then(async () => {
+    const snap = summaryManager.snapshot()
+    const roomsJson = JSON.stringify(snap.rooms)
+    if (roomsJson === lastPersistedRooms) return
+    try {
+      await saveSummarySnapshot(summaryStatePath, snap)
+      lastPersistedRooms = roomsJson
+    } catch (err) {
+      console.error('[summary] Failed to persist summary state:', err)
+    }
+  })
+  return flushChain
 }
 
 // Create event bridge clients
@@ -427,7 +432,10 @@ async function start() {
 }
 
 // Graceful shutdown (SIGINT from a terminal, SIGTERM from Docker)
+let shuttingDown = false
 async function shutdown() {
+  if (shuttingDown) return
+  shuttingDown = true
   console.log('\nShutting down...')
 
   // Persist in-progress sessions, then cancel pending timers — restore()

--- a/src/streamSummary.test.ts
+++ b/src/streamSummary.test.ts
@@ -102,27 +102,6 @@ test('SessionStats with no activity yields empty summary', () => {
   expect(s.topChatters).toEqual([])
 })
 
-test('SessionStats tracks the latest event timestamp as lastEventAt', () => {
-  const stats = new SessionStats(1_000, false)
-  expect(stats.lastEventAt).toBe(1_000) // starts at startedAt
-
-  stats.record(ev('message', { uid: 1, username: 'a', timestampNormalized: 5_000 }))
-  expect(stats.lastEventAt).toBe(5_000)
-
-  // an out-of-order older event must not move it backwards
-  stats.record(ev('online-update', { online: 10, timestampNormalized: 4_000 }))
-  expect(stats.lastEventAt).toBe(5_000)
-
-  stats.record(ev('likes-update', { likes: 3, timestampNormalized: 6_500 }))
-  expect(stats.lastEventAt).toBe(6_500)
-})
-
-test('finalize marks endEstimated only when requested', () => {
-  const stats = new SessionStats(1_000, false)
-  expect(stats.finalize(2_000).endEstimated).toBe(false)
-  expect(stats.finalize(2_000, true).endEstimated).toBe(true)
-})
-
 import type { RoomConfig } from './types'
 
 import { formatSummary } from './streamSummary'
@@ -135,7 +114,6 @@ function baseSummary(): import('./streamSummary').StreamSummary {
     endedAt: 13_320_000,
     durationMs: 13_320_000,
     partial: false,
-    endEstimated: false,
     chats: 3,
     uniqueChatters: 2,
     chatsPerCapita: 1.5,
@@ -208,21 +186,6 @@ test('formatSummary marks partial sessions', () => {
   expect(formatSummary(s, room)).toContain('⚠️ 部分数据')
 })
 
-test('formatSummary renders the endEstimated marker', () => {
-  const s = baseSummary()
-  s.endEstimated = true
-  expect(formatSummary(s, room)).toContain('⚠️ 未观测到下播（服务中断），结束时间为最后活动时间')
-})
-
-test('formatSummary renders both partial and endEstimated markers together', () => {
-  const s = baseSummary()
-  s.partial = true
-  s.endEstimated = true
-  const out = formatSummary(s, room)
-  expect(out).toContain('⚠️ 部分数据（监控中途启动）')
-  expect(out).toContain('⚠️ 未观测到下播（服务中断），结束时间为最后活动时间')
-})
-
 test('formatSummary applies the escaper to viewer-supplied name fields', () => {
   const s = baseSummary()
   const out = formatSummary(s, room, t => `⟦${t}⟧`)
@@ -274,7 +237,6 @@ function makeManager() {
   const calls: Array<{ roomId: number; summary: StreamSummary }> = []
   const manager = new SessionManager({
     debounceMs: 30,
-    revalidateMs: 30,
     onSummary: (roomId, summary) => {
       calls.push({ roomId, summary })
     },
@@ -480,7 +442,6 @@ test('SessionStats snapshot/restore round-trips through JSON', () => {
   const snap: SessionStatsSnapshot = JSON.parse(JSON.stringify(stats.snapshot()))
   const restored = SessionStats.restore(snap)
 
-  expect(restored.lastEventAt).toBe(stats.lastEventAt)
   expect(restored.hasLiveStart).toBe(true)
   expect(restored.finalize(9_000)).toEqual(stats.finalize(9_000))
 })
@@ -525,7 +486,6 @@ test('SessionManager: snapshot captures LIVE and ENDING rooms', () => {
   const room200 = snap.rooms.find(([id]) => id === 200)?.[1]
   expect(room100?.pendingEndAt).toBeNull()
   expect(room100?.session.chats).toBe(1)
-  expect(room100?.session.lastEventAt).toBe(1_100)
   expect(room200?.pendingEndAt).toBe(3_000)
 })
 
@@ -543,7 +503,6 @@ test('SessionManager: a restored ENDING room emits after the debounce', async ()
 
   expect(b.calls.length).toBe(1)
   expect(b.calls[0]?.summary.endedAt).toBe(2_000) // the observed live-end, not wall clock
-  expect(b.calls[0]?.summary.endEstimated).toBe(false)
   expect(b.calls[0]?.summary.chats).toBe(1)
 })
 
@@ -567,53 +526,43 @@ test('SessionManager: a restored ENDING room can still flap-resume', async () =>
   expect(b.calls[0]?.summary.endedAt).toBe(3_000)
 })
 
-test('SessionManager: a restored LIVE room with no activity emits a best-effort summary', async () => {
+test('SessionManager: a restored LIVE session keeps counting across the restart', async () => {
   const a = makeManager()
   a.manager.handle(100, ev('live-start', { timestampNormalized: 1_000 }))
   a.manager.handle(100, ev('message', { uid: 1, username: 'a', timestampNormalized: 1_500 }))
-  const snap = a.manager.snapshot()
-  a.manager.clearAllTimers()
-
-  const b = makeManager()
-  b.manager.restore(snap)
-  await Bun.sleep(60) // past revalidateMs with no events
-
-  expect(b.calls.length).toBe(1)
-  expect(b.calls[0]?.summary.endEstimated).toBe(true)
-  expect(b.calls[0]?.summary.endedAt).toBe(1_500) // lastEventAt, not wall clock
-  expect(b.calls[0]?.summary.chats).toBe(1)
-})
-
-test('SessionManager: any event cancels revalidation and the stream continues', async () => {
-  const a = makeManager()
-  a.manager.handle(100, ev('live-start', { timestampNormalized: 1_000 }))
-  a.manager.handle(100, ev('message', { uid: 1, username: 'a', timestampNormalized: 1_500 }))
-  const snap = a.manager.snapshot()
+  const snap: ManagerSnapshot = JSON.parse(JSON.stringify(a.manager.snapshot()))
   a.manager.clearAllTimers()
 
   const b = makeManager()
   b.manager.restore(snap)
   b.manager.handle(100, ev('message', { uid: 2, username: 'b', timestampNormalized: 5_000 }))
-  await Bun.sleep(60) // past revalidateMs — must NOT fire, the room proved it is live
-  expect(b.calls.length).toBe(0)
-
   b.manager.handle(100, ev('live-end', { timestampNormalized: 6_000 }))
   await Bun.sleep(60)
+
   expect(b.calls.length).toBe(1)
-  expect(b.calls[0]?.summary.endEstimated).toBe(false)
   expect(b.calls[0]?.summary.chats).toBe(2) // pre-restart + post-restart merged
   expect(b.calls[0]?.summary.startedAt).toBe(1_000)
+  expect(b.calls[0]?.summary.endedAt).toBe(6_000)
 })
 
-test('SessionManager: clearAllTimers cancels revalidation timers too', async () => {
+test('SessionManager: a restored LIVE session is superseded by the next live-start', async () => {
   const a = makeManager()
   a.manager.handle(100, ev('live-start', { timestampNormalized: 1_000 }))
+  a.manager.handle(100, ev('message', { uid: 1, username: 'a', timestampNormalized: 1_500 }))
   const snap = a.manager.snapshot()
   a.manager.clearAllTimers()
 
   const b = makeManager()
   b.manager.restore(snap)
-  b.manager.clearAllTimers()
+  // Stream A ended during downtime; stream B starts now (Bilibili double-fires live-start)
+  b.manager.handle(100, ev('live-start', { timestampNormalized: 9_000 }))
+  b.manager.handle(100, ev('live-start', { timestampNormalized: 9_002 }))
+  b.manager.handle(100, ev('message', { uid: 2, username: 'b', timestampNormalized: 9_100 }))
+  b.manager.handle(100, ev('live-end', { timestampNormalized: 10_000 }))
   await Bun.sleep(60)
-  expect(b.calls.length).toBe(0)
+
+  expect(b.calls.length).toBe(1) // stale session A produced no summary
+  expect(b.calls[0]?.summary.startedAt).toBe(9_000) // B anchored at its own start, first fire wins
+  expect(b.calls[0]?.summary.chats).toBe(1) // A's chat dropped, not merged
+  expect(b.calls[0]?.summary.partial).toBe(false)
 })

--- a/src/streamSummary.test.ts
+++ b/src/streamSummary.test.ts
@@ -2,8 +2,9 @@ import { expect, test } from 'bun:test'
 import type { LaplaceEvent } from '@laplace.live/event-types'
 import { md } from '@mtcute/markdown-parser'
 
-import { SessionStats } from './streamSummary'
 import type { SessionStatsSnapshot } from './streamSummary'
+
+import { SessionStats } from './streamSummary'
 
 /** Build a minimal synthetic event for tests (fields not under test are stubbed). */
 function ev(type: string, extra: Record<string, unknown>): LaplaceEvent {

--- a/src/streamSummary.test.ts
+++ b/src/streamSummary.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from 'bun:test'
 import type { LaplaceEvent } from '@laplace.live/event-types'
 import { md } from '@mtcute/markdown-parser'
 
-import type { SessionStatsSnapshot } from './streamSummary'
+import type { ManagerSnapshot, SessionStatsSnapshot } from './streamSummary'
 
 import { SessionStats } from './streamSummary'
 
@@ -274,6 +274,7 @@ function makeManager() {
   const calls: Array<{ roomId: number; summary: StreamSummary }> = []
   const manager = new SessionManager({
     debounceMs: 30,
+    revalidateMs: 30,
     onSummary: (roomId, summary) => {
       calls.push({ roomId, summary })
     },
@@ -505,4 +506,114 @@ test('SessionStats restore preserves a promoted (anchored) partial session', () 
   const restored = SessionStats.restore(stats.snapshot())
   expect(restored.partial).toBe(true)
   expect(restored.hasLiveStart).toBe(true)
+})
+
+test('SessionManager: snapshot captures LIVE and ENDING rooms', () => {
+  const { manager } = makeManager()
+  manager.handle(100, ev('live-start', { timestampNormalized: 1_000 }))
+  manager.handle(100, ev('message', { uid: 1, username: 'a', timestampNormalized: 1_100 }))
+  manager.handle(200, ev('live-start', { timestampNormalized: 2_000 }))
+  manager.handle(200, ev('live-end', { timestampNormalized: 3_000 }))
+
+  const snap = manager.snapshot()
+  manager.clearAllTimers()
+
+  expect(snap.version).toBe(1)
+  expect(typeof snap.savedAt).toBe('number')
+  expect(snap.rooms.length).toBe(2)
+  const room100 = snap.rooms.find(([id]) => id === 100)?.[1]
+  const room200 = snap.rooms.find(([id]) => id === 200)?.[1]
+  expect(room100?.pendingEndAt).toBeNull()
+  expect(room100?.session.chats).toBe(1)
+  expect(room100?.session.lastEventAt).toBe(1_100)
+  expect(room200?.pendingEndAt).toBe(3_000)
+})
+
+test('SessionManager: a restored ENDING room emits after the debounce', async () => {
+  const a = makeManager()
+  a.manager.handle(100, ev('live-start', { timestampNormalized: 1_000 }))
+  a.manager.handle(100, ev('message', { uid: 1, username: 'a', timestampNormalized: 1_100 }))
+  a.manager.handle(100, ev('live-end', { timestampNormalized: 2_000 }))
+  const snap: ManagerSnapshot = JSON.parse(JSON.stringify(a.manager.snapshot()))
+  a.manager.clearAllTimers() // simulate shutdown before the debounce fired
+
+  const b = makeManager()
+  b.manager.restore(snap)
+  await Bun.sleep(60)
+
+  expect(b.calls.length).toBe(1)
+  expect(b.calls[0]?.summary.endedAt).toBe(2_000) // the observed live-end, not wall clock
+  expect(b.calls[0]?.summary.endEstimated).toBe(false)
+  expect(b.calls[0]?.summary.chats).toBe(1)
+})
+
+test('SessionManager: a restored ENDING room can still flap-resume', async () => {
+  const a = makeManager()
+  a.manager.handle(100, ev('live-start', { timestampNormalized: 1_000 }))
+  a.manager.handle(100, ev('live-end', { timestampNormalized: 2_000 }))
+  const snap = a.manager.snapshot()
+  a.manager.clearAllTimers()
+
+  const b = makeManager()
+  b.manager.restore(snap)
+  b.manager.handle(100, ev('live-start', { timestampNormalized: 2_010 })) // resume cancels the re-armed debounce
+  await Bun.sleep(60)
+  expect(b.calls.length).toBe(0)
+
+  b.manager.handle(100, ev('live-end', { timestampNormalized: 3_000 }))
+  await Bun.sleep(60)
+  expect(b.calls.length).toBe(1)
+  expect(b.calls[0]?.summary.startedAt).toBe(1_000)
+  expect(b.calls[0]?.summary.endedAt).toBe(3_000)
+})
+
+test('SessionManager: a restored LIVE room with no activity emits a best-effort summary', async () => {
+  const a = makeManager()
+  a.manager.handle(100, ev('live-start', { timestampNormalized: 1_000 }))
+  a.manager.handle(100, ev('message', { uid: 1, username: 'a', timestampNormalized: 1_500 }))
+  const snap = a.manager.snapshot()
+  a.manager.clearAllTimers()
+
+  const b = makeManager()
+  b.manager.restore(snap)
+  await Bun.sleep(60) // past revalidateMs with no events
+
+  expect(b.calls.length).toBe(1)
+  expect(b.calls[0]?.summary.endEstimated).toBe(true)
+  expect(b.calls[0]?.summary.endedAt).toBe(1_500) // lastEventAt, not wall clock
+  expect(b.calls[0]?.summary.chats).toBe(1)
+})
+
+test('SessionManager: any event cancels revalidation and the stream continues', async () => {
+  const a = makeManager()
+  a.manager.handle(100, ev('live-start', { timestampNormalized: 1_000 }))
+  a.manager.handle(100, ev('message', { uid: 1, username: 'a', timestampNormalized: 1_500 }))
+  const snap = a.manager.snapshot()
+  a.manager.clearAllTimers()
+
+  const b = makeManager()
+  b.manager.restore(snap)
+  b.manager.handle(100, ev('message', { uid: 2, username: 'b', timestampNormalized: 5_000 }))
+  await Bun.sleep(60) // past revalidateMs — must NOT fire, the room proved it is live
+  expect(b.calls.length).toBe(0)
+
+  b.manager.handle(100, ev('live-end', { timestampNormalized: 6_000 }))
+  await Bun.sleep(60)
+  expect(b.calls.length).toBe(1)
+  expect(b.calls[0]?.summary.endEstimated).toBe(false)
+  expect(b.calls[0]?.summary.chats).toBe(2) // pre-restart + post-restart merged
+  expect(b.calls[0]?.summary.startedAt).toBe(1_000)
+})
+
+test('SessionManager: clearAllTimers cancels revalidation timers too', async () => {
+  const a = makeManager()
+  a.manager.handle(100, ev('live-start', { timestampNormalized: 1_000 }))
+  const snap = a.manager.snapshot()
+  a.manager.clearAllTimers()
+
+  const b = makeManager()
+  b.manager.restore(snap)
+  b.manager.clearAllTimers()
+  await Bun.sleep(60)
+  expect(b.calls.length).toBe(0)
 })

--- a/src/streamSummary.test.ts
+++ b/src/streamSummary.test.ts
@@ -3,6 +3,7 @@ import type { LaplaceEvent } from '@laplace.live/event-types'
 import { md } from '@mtcute/markdown-parser'
 
 import { SessionStats } from './streamSummary'
+import type { SessionStatsSnapshot } from './streamSummary'
 
 /** Build a minimal synthetic event for tests (fields not under test are stubbed). */
 function ev(type: string, extra: Record<string, unknown>): LaplaceEvent {
@@ -457,4 +458,50 @@ test('SessionManager: keeps sequential streams in the same room independent', as
   expect(calls[1]?.summary.chats).toBe(1) // not polluted by stream A
   expect(calls[1]?.summary.startedAt).toBe(3_000)
   expect(calls[1]?.summary.endedAt).toBe(4_000)
+})
+
+test('SessionStats snapshot/restore round-trips through JSON', () => {
+  const stats = new SessionStats(1_000, false)
+  stats.record(ev('message', { uid: 1, username: 'a', timestampNormalized: 1_100 }))
+  stats.record(ev('message', { uid: 1, username: 'a', timestampNormalized: 1_200 }))
+  stats.record(ev('message', { uid: 2, username: 'b', timestampNormalized: 1_300 }))
+  stats.record(ev('watched-update', { watched: 250 }))
+  stats.record(ev('online-update', { online: 50 }))
+  stats.record(ev('online-update', { online: 80 }))
+  stats.record(ev('likes-update', { likes: 3_000 }))
+  stats.record(ev('interaction', { action: 2 }))
+  stats.record(ev('gift', { uid: 2, username: 'b', coinType: 'gold', priceNormalized: 30 }))
+  stats.record(ev('superchat', { uid: 3, username: 'c', priceNormalized: 50, message: 'hi' }))
+  stats.record(ev('toast', { uid: 3, username: 'c', priceNormalized: 198 }))
+
+  // Round-trip through actual JSON to prove the snapshot is JSON-safe
+  const snap: SessionStatsSnapshot = JSON.parse(JSON.stringify(stats.snapshot()))
+  const restored = SessionStats.restore(snap)
+
+  expect(restored.lastEventAt).toBe(stats.lastEventAt)
+  expect(restored.hasLiveStart).toBe(true)
+  expect(restored.finalize(9_000)).toEqual(stats.finalize(9_000))
+})
+
+test('SessionStats restore preserves partial/anchor state and keeps accumulating', () => {
+  const stats = new SessionStats(5_000, true) // partial, not yet anchored
+  stats.record(ev('message', { uid: 1, username: 'a', timestampNormalized: 5_100 }))
+
+  const restored = SessionStats.restore(stats.snapshot())
+  expect(restored.partial).toBe(true)
+  expect(restored.hasLiveStart).toBe(false)
+
+  restored.record(ev('message', { uid: 2, username: 'b', timestampNormalized: 5_200 }))
+  const s = restored.finalize(6_000)
+  expect(s.chats).toBe(2)
+  expect(s.uniqueChatters).toBe(2)
+  expect(s.partial).toBe(true)
+})
+
+test('SessionStats restore preserves a promoted (anchored) partial session', () => {
+  const stats = new SessionStats(5_000, true)
+  stats.bindLiveStart() // promoted by a real live-start
+  const restored = SessionStats.restore(stats.snapshot())
+  expect(restored.partial).toBe(true)
+  expect(restored.hasLiveStart).toBe(true)
 })

--- a/src/streamSummary.test.ts
+++ b/src/streamSummary.test.ts
@@ -115,6 +115,12 @@ test('SessionStats tracks the latest event timestamp as lastEventAt', () => {
   expect(stats.lastEventAt).toBe(6_500)
 })
 
+test('finalize marks endEstimated only when requested', () => {
+  const stats = new SessionStats(1_000, false)
+  expect(stats.finalize(2_000).endEstimated).toBe(false)
+  expect(stats.finalize(2_000, true).endEstimated).toBe(true)
+})
+
 import type { RoomConfig } from './types'
 
 import { formatSummary } from './streamSummary'
@@ -127,6 +133,7 @@ function baseSummary(): import('./streamSummary').StreamSummary {
     endedAt: 13_320_000,
     durationMs: 13_320_000,
     partial: false,
+    endEstimated: false,
     chats: 3,
     uniqueChatters: 2,
     chatsPerCapita: 1.5,
@@ -197,6 +204,21 @@ test('formatSummary marks partial sessions', () => {
   const s = baseSummary()
   s.partial = true
   expect(formatSummary(s, room)).toContain('⚠️ 部分数据')
+})
+
+test('formatSummary renders the endEstimated marker', () => {
+  const s = baseSummary()
+  s.endEstimated = true
+  expect(formatSummary(s, room)).toContain('⚠️ 未观测到下播（服务中断），结束时间为最后活动时间')
+})
+
+test('formatSummary renders both partial and endEstimated markers together', () => {
+  const s = baseSummary()
+  s.partial = true
+  s.endEstimated = true
+  const out = formatSummary(s, room)
+  expect(out).toContain('⚠️ 部分数据（监控中途启动）')
+  expect(out).toContain('⚠️ 未观测到下播（服务中断），结束时间为最后活动时间')
 })
 
 test('formatSummary applies the escaper to viewer-supplied name fields', () => {

--- a/src/streamSummary.test.ts
+++ b/src/streamSummary.test.ts
@@ -543,6 +543,7 @@ test('SessionManager: a restored LIVE session keeps counting across the restart'
   expect(b.calls[0]?.summary.chats).toBe(2) // pre-restart + post-restart merged
   expect(b.calls[0]?.summary.startedAt).toBe(1_000)
   expect(b.calls[0]?.summary.endedAt).toBe(6_000)
+  expect(b.calls[0]?.summary.partial).toBe(false) // non-partial despite the cleared anchor
 })
 
 test('SessionManager: a restored LIVE session is superseded by the next live-start', async () => {

--- a/src/streamSummary.test.ts
+++ b/src/streamSummary.test.ts
@@ -100,6 +100,21 @@ test('SessionStats with no activity yields empty summary', () => {
   expect(s.topChatters).toEqual([])
 })
 
+test('SessionStats tracks the latest event timestamp as lastEventAt', () => {
+  const stats = new SessionStats(1_000, false)
+  expect(stats.lastEventAt).toBe(1_000) // starts at startedAt
+
+  stats.record(ev('message', { uid: 1, username: 'a', timestampNormalized: 5_000 }))
+  expect(stats.lastEventAt).toBe(5_000)
+
+  // an out-of-order older event must not move it backwards
+  stats.record(ev('online-update', { online: 10, timestampNormalized: 4_000 }))
+  expect(stats.lastEventAt).toBe(5_000)
+
+  stats.record(ev('likes-update', { likes: 3, timestampNormalized: 6_500 }))
+  expect(stats.lastEventAt).toBe(6_500)
+})
+
 import type { RoomConfig } from './types'
 
 import { formatSummary } from './streamSummary'

--- a/src/streamSummary.ts
+++ b/src/streamSummary.ts
@@ -10,6 +10,8 @@ export interface StreamSummary {
   durationMs: number
   /** true when no live-start was observed (bot started mid-stream); numbers are a lower bound. */
   partial: boolean
+  /** true when no live-end was observed (stream ended while the bot was down); endedAt is the last event seen — a lower bound. */
+  endEstimated: boolean
   chats: number
   uniqueChatters: number
   /** chats / uniqueChatters (0 when nobody chatted). */
@@ -158,7 +160,7 @@ export class SessionStats {
     }
   }
 
-  finalize(endedAt: number): StreamSummary {
+  finalize(endedAt: number, endEstimated = false): StreamSummary {
     const topChatters = [...this.chatters.entries()]
       .map(([uid, v]) => ({ uid, name: v.name, count: v.count }))
       .sort((a, b) => b.count - a.count)
@@ -177,6 +179,7 @@ export class SessionStats {
       endedAt,
       durationMs,
       partial: this.partial,
+      endEstimated,
       chats: this.chats,
       uniqueChatters: this.chatters.size,
       chatsPerCapita: this.chatters.size > 0 ? this.chats / this.chatters.size : 0,
@@ -234,6 +237,7 @@ export function formatSummary(
 
   let header = `#${room.slug} #直播总结`
   if (s.partial) header = `⚠️ 部分数据（监控中途启动）\n${header}`
+  if (s.endEstimated) header = `⚠️ 未观测到下播（服务中断），结束时间为最后活动时间\n${header}`
   blocks.push(header)
 
   blocks.push(`🕐 时长 ${formatDuration(s.durationMs)}  ·  ${clock(s.startedAt)} → ${clock(s.endedAt)}`)

--- a/src/streamSummary.ts
+++ b/src/streamSummary.ts
@@ -81,6 +81,7 @@ export interface RoomSnapshot {
 
 /** JSON-safe serialized form of SessionManager (timers are re-derived on restore). */
 export interface ManagerSnapshot {
+  /** Bump when the snapshot shape changes — old files are discarded on load. */
   version: 1
   savedAt: number
   rooms: Array<[number, RoomSnapshot]>

--- a/src/streamSummary.ts
+++ b/src/streamSummary.ts
@@ -2,7 +2,6 @@ import type { LaplaceEvent } from '@laplace.live/event-types'
 
 import type { RoomConfig } from './types'
 
-import { STREAM_SUMMARY_REVALIDATE_MS } from './consts'
 import { formatDuration } from './utils'
 
 export interface StreamSummary {
@@ -11,8 +10,6 @@ export interface StreamSummary {
   durationMs: number
   /** true when no live-start was observed (bot started mid-stream); numbers are a lower bound. */
   partial: boolean
-  /** true when no live-end was observed (stream ended while the bot was down); endedAt is the last event seen — a lower bound. */
-  endEstimated: boolean
   chats: number
   uniqueChatters: number
   /** chats / uniqueChatters (0 when nobody chatted). */
@@ -55,7 +52,6 @@ export interface SessionStatsSnapshot {
   startedAt: number
   partial: boolean
   liveStartBound: boolean
-  lastEventAt: number
   chats: number
   chatters: Array<[number, { name: string; count: number }]>
   watchedMax: number
@@ -101,8 +97,6 @@ export class SessionStats {
    * twice on every start) from re-anchoring a session that is already running.
    */
   private liveStartBound: boolean
-  /** Timestamp of the most recent recorded event (never below startedAt). */
-  private lastActivity: number
 
   private chats = 0
   private readonly chatters = new Map<number, { name: string; count: number }>()
@@ -127,17 +121,11 @@ export class SessionStats {
     // A non-partial session was opened by a live-start; a partial one was
     // opened by a stray recordable event and has not yet seen its start.
     this.liveStartBound = !partial
-    this.lastActivity = startedAt
   }
 
   /** Whether a live-start has already anchored this session. */
   get hasLiveStart(): boolean {
     return this.liveStartBound
-  }
-
-  /** Most recent recorded event's timestamp (startedAt when nothing has been recorded yet). */
-  get lastEventAt(): number {
-    return this.lastActivity
   }
 
   /** Record that a live-start has now anchored this session (promotion or flap-resume). */
@@ -153,7 +141,6 @@ export class SessionStats {
   }
 
   record(event: LaplaceEvent): void {
-    if (event.timestampNormalized > this.lastActivity) this.lastActivity = event.timestampNormalized
     switch (event.type) {
       case 'message': {
         this.chats++
@@ -198,7 +185,7 @@ export class SessionStats {
     }
   }
 
-  finalize(endedAt: number, endEstimated = false): StreamSummary {
+  finalize(endedAt: number): StreamSummary {
     const topChatters = [...this.chatters.entries()]
       .map(([uid, v]) => ({ uid, name: v.name, count: v.count }))
       .sort((a, b) => b.count - a.count)
@@ -217,7 +204,6 @@ export class SessionStats {
       endedAt,
       durationMs,
       partial: this.partial,
-      endEstimated,
       chats: this.chats,
       uniqueChatters: this.chatters.size,
       chatsPerCapita: this.chatters.size > 0 ? this.chats / this.chatters.size : 0,
@@ -246,7 +232,6 @@ export class SessionStats {
       startedAt: this.startedAt,
       partial: this.partial,
       liveStartBound: this.liveStartBound,
-      lastEventAt: this.lastActivity,
       chats: this.chats,
       chatters,
       watchedMax: this.watchedMax,
@@ -269,7 +254,6 @@ export class SessionStats {
   static restore(snap: SessionStatsSnapshot): SessionStats {
     const s = new SessionStats(snap.startedAt, snap.partial)
     s.liveStartBound = snap.liveStartBound
-    s.lastActivity = snap.lastEventAt
     s.chats = snap.chats
     for (const [uid, v] of snap.chatters) s.chatters.set(uid, { ...v })
     s.watchedMax = snap.watchedMax
@@ -327,7 +311,6 @@ export function formatSummary(
 
   let header = `#${room.slug} #直播总结`
   if (s.partial) header = `⚠️ 部分数据（监控中途启动）\n${header}`
-  if (s.endEstimated) header = `⚠️ 未观测到下播（服务中断），结束时间为最后活动时间\n${header}`
   blocks.push(header)
 
   blocks.push(`🕐 时长 ${formatDuration(s.durationMs)}  ·  ${clock(s.startedAt)} → ${clock(s.endedAt)}`)
@@ -380,11 +363,6 @@ export function formatSummary(
 
 export interface SessionManagerOptions {
   debounceMs: number
-  /**
-   * Silence window after restoring a LIVE room before declaring the stream
-   * ended during downtime (defaults to STREAM_SUMMARY_REVALIDATE_MS).
-   */
-  revalidateMs?: number
   onSummary: (roomId: number, summary: StreamSummary) => void | Promise<void>
 }
 
@@ -401,28 +379,15 @@ export class SessionManager {
   private readonly sessions = new Map<number, SessionStats>()
   private readonly timers = new Map<number, ReturnType<typeof setTimeout>>()
   private readonly pendingEndAt = new Map<number, number>()
-  private readonly revalidateMs: number
-  private readonly revalidateTimers = new Map<number, ReturnType<typeof setTimeout>>()
 
   constructor(opts: SessionManagerOptions) {
     this.debounceMs = opts.debounceMs
     this.onSummary = opts.onSummary
-    this.revalidateMs = opts.revalidateMs ?? STREAM_SUMMARY_REVALIDATE_MS
-  }
-
-  /** Cancel a pending post-restore revalidation: the room has shown signs of life. */
-  private cancelRevalidation(roomId: number): void {
-    const timer = this.revalidateTimers.get(roomId)
-    if (timer) {
-      clearTimeout(timer)
-      this.revalidateTimers.delete(roomId)
-    }
   }
 
   handle(roomId: number, event: LaplaceEvent): void {
     switch (event.type) {
       case 'live-start': {
-        this.cancelRevalidation(roomId)
         const timer = this.timers.get(roomId)
         if (timer) {
           // ENDING -> resume: brief blip, keep counting the same session. The
@@ -448,7 +413,6 @@ export class SessionManager {
         return
       }
       case 'live-end': {
-        this.cancelRevalidation(roomId)
         if (!this.sessions.has(roomId)) return // IDLE -> nothing to end
         this.pendingEndAt.set(roomId, event.timestampNormalized)
         const existing = this.timers.get(roomId)
@@ -461,7 +425,6 @@ export class SessionManager {
       }
       default: {
         if (!RECORDABLE_TYPES.has(event.type)) return
-        this.cancelRevalidation(roomId)
         let session = this.sessions.get(roomId)
         if (!session) {
           // Bot started mid-stream: no live-start was seen -> partial session
@@ -478,8 +441,6 @@ export class SessionManager {
   clearAllTimers(): void {
     for (const timer of this.timers.values()) clearTimeout(timer)
     this.timers.clear()
-    for (const timer of this.revalidateTimers.values()) clearTimeout(timer)
-    this.revalidateTimers.clear()
   }
 
   /** Serialize all rooms' in-progress state (JSON-safe; timers are re-derived on restore). */
@@ -493,40 +454,23 @@ export class SessionManager {
 
   /**
    * Rehydrate sessions from a snapshot (startup only). ENDING rooms re-arm the
-   * debounce; LIVE rooms get one revalidation window before a best-effort summary.
+   * debounce. LIVE rooms are restored unanchored: if the stream ended while the
+   * bot was down, the next live-start supersedes the stale session (its data is
+   * dropped, no summary) instead of merging two streams into one.
    */
   restore(snap: ManagerSnapshot): void {
     for (const [roomId, room] of snap.rooms) {
-      this.sessions.set(roomId, SessionStats.restore(room.session))
       if (room.pendingEndAt !== null) {
+        this.sessions.set(roomId, SessionStats.restore(room.session))
         this.pendingEndAt.set(roomId, room.pendingEndAt)
         this.timers.set(
           roomId,
           setTimeout(() => this.finalizeRoom(roomId), this.debounceMs)
         )
       } else {
-        this.revalidateTimers.set(
-          roomId,
-          setTimeout(() => this.finalizeStale(roomId), this.revalidateMs)
-        )
+        this.sessions.set(roomId, SessionStats.restore({ ...room.session, liveStartBound: false }))
       }
     }
-  }
-
-  /**
-   * Post-restore revalidation expired with no activity: the stream ended while
-   * the bot was down. Emit a best-effort summary bounded by the last event seen.
-   */
-  private finalizeStale(roomId: number): void {
-    this.revalidateTimers.delete(roomId)
-    const session = this.sessions.get(roomId)
-    this.sessions.delete(roomId)
-    if (!session) return
-
-    const summary = session.finalize(session.lastEventAt, true)
-    Promise.resolve(this.onSummary(roomId, summary)).catch(err =>
-      console.error(`[summary] onSummary failed for room ${roomId}:`, err)
-    )
   }
 
   private finalizeRoom(roomId: number): void {

--- a/src/streamSummary.ts
+++ b/src/streamSummary.ts
@@ -61,6 +61,8 @@ export class SessionStats {
    * twice on every start) from re-anchoring a session that is already running.
    */
   private liveStartBound: boolean
+  /** Timestamp of the most recent recorded event (never below startedAt). */
+  private lastActivity: number
 
   private chats = 0
   private readonly chatters = new Map<number, { name: string; count: number }>()
@@ -85,11 +87,17 @@ export class SessionStats {
     // A non-partial session was opened by a live-start; a partial one was
     // opened by a stray recordable event and has not yet seen its start.
     this.liveStartBound = !partial
+    this.lastActivity = startedAt
   }
 
   /** Whether a live-start has already anchored this session. */
   get hasLiveStart(): boolean {
     return this.liveStartBound
+  }
+
+  /** Most recent recorded event's timestamp (startedAt when nothing has been recorded yet). */
+  get lastEventAt(): number {
+    return this.lastActivity
   }
 
   /** Record that a live-start has now anchored this session (promotion or flap-resume). */
@@ -105,6 +113,7 @@ export class SessionStats {
   }
 
   record(event: LaplaceEvent): void {
+    if (event.timestampNormalized > this.lastActivity) this.lastActivity = event.timestampNormalized
     switch (event.type) {
       case 'message': {
         this.chats++

--- a/src/streamSummary.ts
+++ b/src/streamSummary.ts
@@ -2,6 +2,7 @@ import type { LaplaceEvent } from '@laplace.live/event-types'
 
 import type { RoomConfig } from './types'
 
+import { STREAM_SUMMARY_REVALIDATE_MS } from './consts'
 import { formatDuration } from './utils'
 
 export interface StreamSummary {
@@ -70,6 +71,19 @@ export interface SessionStatsSnapshot {
   guardCount: number
   guardRevenue: number
   spenders: Array<[number, { name: string; total: number }]>
+}
+
+/** One room's persisted state: its session plus the pending end (ENDING state) if any. */
+export interface RoomSnapshot {
+  pendingEndAt: number | null
+  session: SessionStatsSnapshot
+}
+
+/** JSON-safe serialized form of SessionManager (timers are re-derived on restore). */
+export interface ManagerSnapshot {
+  version: 1
+  savedAt: number
+  rooms: Array<[number, RoomSnapshot]>
 }
 
 /** In-memory accumulator for a single live session. Pure: no I/O. */
@@ -365,6 +379,11 @@ export function formatSummary(
 
 export interface SessionManagerOptions {
   debounceMs: number
+  /**
+   * Silence window after restoring a LIVE room before declaring the stream
+   * ended during downtime (defaults to STREAM_SUMMARY_REVALIDATE_MS).
+   */
+  revalidateMs?: number
   onSummary: (roomId: number, summary: StreamSummary) => void | Promise<void>
 }
 
@@ -381,15 +400,28 @@ export class SessionManager {
   private readonly sessions = new Map<number, SessionStats>()
   private readonly timers = new Map<number, ReturnType<typeof setTimeout>>()
   private readonly pendingEndAt = new Map<number, number>()
+  private readonly revalidateMs: number
+  private readonly revalidateTimers = new Map<number, ReturnType<typeof setTimeout>>()
 
   constructor(opts: SessionManagerOptions) {
     this.debounceMs = opts.debounceMs
     this.onSummary = opts.onSummary
+    this.revalidateMs = opts.revalidateMs ?? STREAM_SUMMARY_REVALIDATE_MS
+  }
+
+  /** Cancel a pending post-restore revalidation: the room has shown signs of life. */
+  private cancelRevalidation(roomId: number): void {
+    const timer = this.revalidateTimers.get(roomId)
+    if (timer) {
+      clearTimeout(timer)
+      this.revalidateTimers.delete(roomId)
+    }
   }
 
   handle(roomId: number, event: LaplaceEvent): void {
     switch (event.type) {
       case 'live-start': {
+        this.cancelRevalidation(roomId)
         const timer = this.timers.get(roomId)
         if (timer) {
           // ENDING -> resume: brief blip, keep counting the same session. The
@@ -415,6 +447,7 @@ export class SessionManager {
         return
       }
       case 'live-end': {
+        this.cancelRevalidation(roomId)
         if (!this.sessions.has(roomId)) return // IDLE -> nothing to end
         this.pendingEndAt.set(roomId, event.timestampNormalized)
         const existing = this.timers.get(roomId)
@@ -427,6 +460,7 @@ export class SessionManager {
       }
       default: {
         if (!RECORDABLE_TYPES.has(event.type)) return
+        this.cancelRevalidation(roomId)
         let session = this.sessions.get(roomId)
         if (!session) {
           // Bot started mid-stream: no live-start was seen -> partial session
@@ -439,10 +473,59 @@ export class SessionManager {
     }
   }
 
-  /** Cancel all pending debounce timers (e.g. on shutdown). */
+  /** Cancel all pending timers (e.g. on shutdown). */
   clearAllTimers(): void {
     for (const timer of this.timers.values()) clearTimeout(timer)
     this.timers.clear()
+    for (const timer of this.revalidateTimers.values()) clearTimeout(timer)
+    this.revalidateTimers.clear()
+  }
+
+  /** Serialize all rooms' in-progress state (JSON-safe; timers are re-derived on restore). */
+  snapshot(): ManagerSnapshot {
+    const rooms: Array<[number, RoomSnapshot]> = []
+    for (const [roomId, session] of this.sessions) {
+      rooms.push([roomId, { pendingEndAt: this.pendingEndAt.get(roomId) ?? null, session: session.snapshot() }])
+    }
+    return { version: 1, savedAt: Date.now(), rooms }
+  }
+
+  /**
+   * Rehydrate sessions from a snapshot (startup only). ENDING rooms re-arm the
+   * debounce; LIVE rooms get one revalidation window before a best-effort summary.
+   */
+  restore(snap: ManagerSnapshot): void {
+    for (const [roomId, room] of snap.rooms) {
+      this.sessions.set(roomId, SessionStats.restore(room.session))
+      if (room.pendingEndAt !== null) {
+        this.pendingEndAt.set(roomId, room.pendingEndAt)
+        this.timers.set(
+          roomId,
+          setTimeout(() => this.finalizeRoom(roomId), this.debounceMs)
+        )
+      } else {
+        this.revalidateTimers.set(
+          roomId,
+          setTimeout(() => this.finalizeStale(roomId), this.revalidateMs)
+        )
+      }
+    }
+  }
+
+  /**
+   * Post-restore revalidation expired with no activity: the stream ended while
+   * the bot was down. Emit a best-effort summary bounded by the last event seen.
+   */
+  private finalizeStale(roomId: number): void {
+    this.revalidateTimers.delete(roomId)
+    const session = this.sessions.get(roomId)
+    this.sessions.delete(roomId)
+    if (!session) return
+
+    const summary = session.finalize(session.lastEventAt, true)
+    Promise.resolve(this.onSummary(roomId, summary)).catch(err =>
+      console.error(`[summary] onSummary failed for room ${roomId}:`, err)
+    )
   }
 
   private finalizeRoom(roomId: number): void {

--- a/src/streamSummary.ts
+++ b/src/streamSummary.ts
@@ -49,6 +49,29 @@ export const RECORDABLE_TYPES = new Set<string>([
 /** Max entries shown in each leaderboard (金主榜 / 弹幕榜). */
 const TOP_N = 10
 
+/** JSON-safe serialized form of SessionStats (Maps as entry arrays). */
+export interface SessionStatsSnapshot {
+  startedAt: number
+  partial: boolean
+  liveStartBound: boolean
+  lastEventAt: number
+  chats: number
+  chatters: Array<[number, { name: string; count: number }]>
+  watchedMax: number
+  onlinePeak: number
+  onlineSum: number
+  onlineSamples: number
+  likesMax: number
+  newFollows: number
+  giftCount: number
+  giftRevenue: number
+  scCount: number
+  scRevenue: number
+  guardCount: number
+  guardRevenue: number
+  spenders: Array<[number, { name: string; total: number }]>
+}
+
 /** In-memory accumulator for a single live session. Pure: no I/O. */
 export class SessionStats {
   readonly startedAt: number
@@ -196,6 +219,58 @@ export class SessionStats {
       topSpenders,
       topChatters,
     }
+  }
+
+  /** Serialize every accumulator field into a JSON-safe object. */
+  snapshot(): SessionStatsSnapshot {
+    const chatters: Array<[number, { name: string; count: number }]> = []
+    for (const [uid, v] of this.chatters) chatters.push([uid, { ...v }])
+    const spenders: Array<[number, { name: string; total: number }]> = []
+    for (const [uid, v] of this.spenders) spenders.push([uid, { ...v }])
+    return {
+      startedAt: this.startedAt,
+      partial: this.partial,
+      liveStartBound: this.liveStartBound,
+      lastEventAt: this.lastActivity,
+      chats: this.chats,
+      chatters,
+      watchedMax: this.watchedMax,
+      onlinePeak: this.onlinePeak,
+      onlineSum: this.onlineSum,
+      onlineSamples: this.onlineSamples,
+      likesMax: this.likesMax,
+      newFollows: this.newFollows,
+      giftCount: this.giftCount,
+      giftRevenue: this.giftRevenue,
+      scCount: this.scCount,
+      scRevenue: this.scRevenue,
+      guardCount: this.guardCount,
+      guardRevenue: this.guardRevenue,
+      spenders,
+    }
+  }
+
+  /** Exact inverse of snapshot(): restore(x.snapshot()).finalize(t) deep-equals x.finalize(t). */
+  static restore(snap: SessionStatsSnapshot): SessionStats {
+    const s = new SessionStats(snap.startedAt, snap.partial)
+    s.liveStartBound = snap.liveStartBound
+    s.lastActivity = snap.lastEventAt
+    s.chats = snap.chats
+    for (const [uid, v] of snap.chatters) s.chatters.set(uid, { ...v })
+    s.watchedMax = snap.watchedMax
+    s.onlinePeak = snap.onlinePeak
+    s.onlineSum = snap.onlineSum
+    s.onlineSamples = snap.onlineSamples
+    s.likesMax = snap.likesMax
+    s.newFollows = snap.newFollows
+    s.giftCount = snap.giftCount
+    s.giftRevenue = snap.giftRevenue
+    s.scCount = snap.scCount
+    s.scRevenue = snap.scRevenue
+    s.guardCount = snap.guardCount
+    s.guardRevenue = snap.guardRevenue
+    for (const [uid, v] of snap.spenders) s.spenders.set(uid, { ...v })
+    return s
   }
 }
 

--- a/src/summaryPersistence.test.ts
+++ b/src/summaryPersistence.test.ts
@@ -27,7 +27,6 @@ function fixture(): ManagerSnapshot {
             startedAt: 1_000,
             partial: false,
             liveStartBound: true,
-            lastEventAt: 1_500,
             chats: 1,
             chatters: [[1, { name: 'a', count: 1 }]],
             watchedMax: 250,

--- a/src/summaryPersistence.test.ts
+++ b/src/summaryPersistence.test.ts
@@ -69,6 +69,26 @@ test('load returns null for an unsupported version', async () => {
   expect(await loadSummarySnapshot(path)).toBeNull()
 })
 
+test('load returns null when rooms is not an array', async () => {
+  await Bun.write(path, '{"version":1,"savedAt":0,"rooms":{}}')
+  expect(await loadSummarySnapshot(path)).toBeNull()
+})
+
+test('load returns null for a room entry with a null value', async () => {
+  await Bun.write(path, '{"version":1,"savedAt":0,"rooms":[[100,null]]}')
+  expect(await loadSummarySnapshot(path)).toBeNull()
+})
+
+test('load returns null when a room session is null', async () => {
+  await Bun.write(path, '{"version":1,"savedAt":0,"rooms":[[100,{"pendingEndAt":null,"session":null}]]}')
+  expect(await loadSummarySnapshot(path)).toBeNull()
+})
+
+test('load returns null when a session is missing its chatters array', async () => {
+  await Bun.write(path, '{"version":1,"savedAt":0,"rooms":[[100,{"pendingEndAt":null,"session":{"spenders":[]}}]]}')
+  expect(await loadSummarySnapshot(path)).toBeNull()
+})
+
 test('save leaves no tmp file behind', async () => {
   await saveSummarySnapshot(path, fixture())
   expect(await Bun.file(`${path}.tmp`).exists()).toBe(false)

--- a/src/summaryPersistence.test.ts
+++ b/src/summaryPersistence.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, expect, test } from 'bun:test'
+import { unlink } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { ManagerSnapshot } from './streamSummary'
+
+import { loadSummarySnapshot, saveSummarySnapshot } from './summaryPersistence'
+
+const path = join(tmpdir(), `laplace-jupiter-summary-state-${process.pid}.json`)
+
+afterEach(async () => {
+  await unlink(path).catch(() => {})
+  await unlink(`${path}.tmp`).catch(() => {})
+})
+
+function fixture(): ManagerSnapshot {
+  return {
+    version: 1,
+    savedAt: 1_751_400_000_000,
+    rooms: [
+      [
+        100,
+        {
+          pendingEndAt: null,
+          session: {
+            startedAt: 1_000,
+            partial: false,
+            liveStartBound: true,
+            lastEventAt: 1_500,
+            chats: 1,
+            chatters: [[1, { name: 'a', count: 1 }]],
+            watchedMax: 250,
+            onlinePeak: 80,
+            onlineSum: 130,
+            onlineSamples: 2,
+            likesMax: 3_000,
+            newFollows: 2,
+            giftCount: 2,
+            giftRevenue: 40,
+            scCount: 2,
+            scRevenue: 150,
+            guardCount: 2,
+            guardRevenue: 396,
+            spenders: [[3, { name: 'c', total: 248 }]],
+          },
+        },
+      ],
+    ],
+  }
+}
+
+test('save/load round-trips a snapshot', async () => {
+  await saveSummarySnapshot(path, fixture())
+  expect(await loadSummarySnapshot(path)).toEqual(fixture())
+})
+
+test('load returns null for a missing file', async () => {
+  expect(await loadSummarySnapshot(path)).toBeNull()
+})
+
+test('load returns null for corrupt JSON', async () => {
+  await Bun.write(path, '{not json')
+  expect(await loadSummarySnapshot(path)).toBeNull()
+})
+
+test('load returns null for an unsupported version', async () => {
+  await Bun.write(path, JSON.stringify({ version: 99, savedAt: 0, rooms: [] }))
+  expect(await loadSummarySnapshot(path)).toBeNull()
+})
+
+test('save leaves no tmp file behind', async () => {
+  await saveSummarySnapshot(path, fixture())
+  expect(await Bun.file(`${path}.tmp`).exists()).toBe(false)
+})
+
+test('save overwrites a previous snapshot atomically', async () => {
+  await saveSummarySnapshot(path, fixture())
+  const next = fixture()
+  next.savedAt = 1_751_400_010_000
+  next.rooms = []
+  await saveSummarySnapshot(path, next)
+  expect(await loadSummarySnapshot(path)).toEqual(next)
+})

--- a/src/summaryPersistence.test.ts
+++ b/src/summaryPersistence.test.ts
@@ -89,6 +89,22 @@ test('load returns null when a session is missing its chatters array', async () 
   expect(await loadSummarySnapshot(path)).toBeNull()
 })
 
+test('load returns null when a chatters entry is null', async () => {
+  await Bun.write(
+    path,
+    '{"version":1,"savedAt":0,"rooms":[[100,{"pendingEndAt":null,"session":{"chatters":[null],"spenders":[]}}]]}'
+  )
+  expect(await loadSummarySnapshot(path)).toBeNull()
+})
+
+test('load returns null when a chatters entry is an object instead of a tuple', async () => {
+  await Bun.write(
+    path,
+    '{"version":1,"savedAt":0,"rooms":[[100,{"pendingEndAt":null,"session":{"chatters":[{"uid":1,"name":"a","count":1}],"spenders":[]}}]]}'
+  )
+  expect(await loadSummarySnapshot(path)).toBeNull()
+})
+
 test('save leaves no tmp file behind', async () => {
   await saveSummarySnapshot(path, fixture())
   expect(await Bun.file(`${path}.tmp`).exists()).toBe(false)

--- a/src/summaryPersistence.ts
+++ b/src/summaryPersistence.ts
@@ -2,15 +2,17 @@ import { rename } from 'node:fs/promises'
 
 import type { ManagerSnapshot, RoomSnapshot } from './streamSummary'
 
-/** Guards only what restore() dereferences; malformed scalars can't crash restore. */
+/** Guards only the shapes restore() destructures; malformed entry contents can't crash restore. */
 function isRestorableRoom(entry: [number, RoomSnapshot]): boolean {
-  const session = entry?.[1]?.session
+  if (!Array.isArray(entry)) return false
+  const session = entry[1]?.session
   return (
-    Array.isArray(entry) &&
     session !== null &&
     typeof session === 'object' &&
     Array.isArray(session.chatters) &&
-    Array.isArray(session.spenders)
+    session.chatters.every(Array.isArray) &&
+    Array.isArray(session.spenders) &&
+    session.spenders.every(Array.isArray)
   )
 }
 

--- a/src/summaryPersistence.ts
+++ b/src/summaryPersistence.ts
@@ -1,6 +1,18 @@
 import { rename } from 'node:fs/promises'
 
-import type { ManagerSnapshot } from './streamSummary'
+import type { ManagerSnapshot, RoomSnapshot } from './streamSummary'
+
+/** Guards only what restore() dereferences; malformed scalars can't crash restore. */
+function isRestorableRoom(entry: [number, RoomSnapshot]): boolean {
+  const session = entry?.[1]?.session
+  return (
+    Array.isArray(entry) &&
+    session !== null &&
+    typeof session === 'object' &&
+    Array.isArray(session.chatters) &&
+    Array.isArray(session.spenders)
+  )
+}
 
 /**
  * Read a previously saved summary snapshot. Returns null (never throws) when
@@ -12,7 +24,7 @@ export async function loadSummarySnapshot(path: string): Promise<ManagerSnapshot
   if (!(await file.exists())) return null
   try {
     const data: ManagerSnapshot = await file.json()
-    if (data?.version !== 1 || !Array.isArray(data.rooms)) {
+    if (data?.version !== 1 || !Array.isArray(data.rooms) || !data.rooms.every(isRestorableRoom)) {
       console.warn(`[summary] Discarding snapshot with unsupported shape/version: ${path}`)
       return null
     }

--- a/src/summaryPersistence.ts
+++ b/src/summaryPersistence.ts
@@ -1,0 +1,35 @@
+import { rename } from 'node:fs/promises'
+
+import type { ManagerSnapshot } from './streamSummary'
+
+/**
+ * Read a previously saved summary snapshot. Returns null (never throws) when
+ * the file is missing, unparseable, or has an unsupported version — the bot
+ * then simply starts with empty state.
+ */
+export async function loadSummarySnapshot(path: string): Promise<ManagerSnapshot | null> {
+  const file = Bun.file(path)
+  if (!(await file.exists())) return null
+  try {
+    const data: ManagerSnapshot = await file.json()
+    if (data?.version !== 1 || !Array.isArray(data.rooms)) {
+      console.warn(`[summary] Discarding snapshot with unsupported shape/version: ${path}`)
+      return null
+    }
+    return data
+  } catch (err) {
+    console.warn(`[summary] Discarding unreadable snapshot ${path}:`, err)
+    return null
+  }
+}
+
+/**
+ * Atomically persist a snapshot: write <path>.tmp, then rename over <path>.
+ * A crash mid-write leaves the previous snapshot intact (POSIX rename).
+ * Throws on I/O failure — callers log and carry on.
+ */
+export async function saveSummarySnapshot(path: string, snap: ManagerSnapshot): Promise<void> {
+  const tmp = `${path}.tmp`
+  await Bun.write(tmp, JSON.stringify(snap))
+  await rename(tmp, path)
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stream summary state is now saved and restored across restarts (periodic atomic snapshotting), helping in-progress streams survive crashes or upgrades.
  * Restored summaries provide best-effort results, with clearer markers when an end is inferred.
* **Bug Fixes**
  * Improved reliability of persistence with atomic writes and safer recovery from invalid/corrupt saved state.
  * Shutdown now flushes summary state before exit and handles both SIGINT and SIGTERM.
* **Documentation**
  * README updated to clarify stream-summary persistence behavior and required Docker volume mounting for `bot-data/`.
  * Added contributor-oriented TypeScript/code comment conventions.
* **Tests**
  * Added snapshot/restore and persistence test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->